### PR TITLE
NO JIRA Rules to check files.xml were skipped because of erroneous dependsOn

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -69,15 +69,15 @@ object ProfileVersion0 {
     NumberedRule("3.1.7", pointsHaveAtLeastTwoValues, dependsOn = Some("3.1.1")),
 
     // files.xml
-    NumberedRule("3.2.1", filesXmlConformsToSchemaIfDeclaredInDefaultNamespace(xmlValidators("files.xml")), dependsOn = Some("2.3")),
-    NumberedRule("3.2.2", filesXmlHasDocumentElementFiles, dependsOn = Some("2.3")),
+    NumberedRule("3.2.1", filesXmlConformsToSchemaIfDeclaredInDefaultNamespace(xmlValidators("files.xml")), dependsOn = Some("2.2")),
+    NumberedRule("3.2.2", filesXmlHasDocumentElementFiles, dependsOn = Some("2.2")),
     NumberedRule("3.2.3", filesXmlHasOnlyFiles, dependsOn = Some("3.2.2")),
 
     NumberedRule("3.2.4", filesXmlFileElementsAllHaveFilepathAttribute, dependsOn = Some("3.2.3")),
     // Second part of 3.2.4 (directories not described) is implicitly checked by 3.2.5
     NumberedRule("3.2.5", filesXmlAllFilesDescribedOnce, dependsOn = Some("3.2.4")),
-    NumberedRule("3.2.6", filesXmlAllFilesHaveFormat, dependsOn = Some("3.2.3")),
-    NumberedRule("3.2.7", filesXmlFilesHaveOnlyDcTerms, dependsOn = Some("3.2.3")),
+    NumberedRule("3.2.6", filesXmlAllFilesHaveFormat, dependsOn = Some("3.2.2")),
+    NumberedRule("3.2.7", filesXmlFilesHaveOnlyDcTerms, dependsOn = Some("3.2.2")),
 
     // agreements.xml
     NumberedRule("3.3.1", xmlFileIfExistsConformsToSchema(Paths.get("metadata/agreements.xml"), "Agreements metadata schema", xmlValidators("agreements.xml"))),

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -273,9 +273,9 @@ package object metadata extends DebugEnhancedLogging {
       else {
         val msg =
           (if (noDuplicatesFound) ""
-           else s" - Duplicate filepaths found: ${ duplicatePathsInFilesXml.mkString(", ") }\n") +
+           else s"   - Duplicate filepaths found: ${ duplicatePathsInFilesXml.mkString(", ") }\n") +
             (if (fileSetsEqual) ""
-             else s" - Filepaths in files.xml not equal to files found in data folder. Difference: " +
+             else s"   - Filepaths in files.xml not equal to files found in data folder. Difference: " +
                s"(only in bag: ${ (payloadPaths diff pathsInFileXml).mkString(", ") }, only in files.xml: " +
                s"${ (pathsInFileXml diff payloadPaths).mkString(", ") }\n")
         fail(s"files.xml: errors in filepath-attributes:\n$msg")


### PR DESCRIPTION
#### When applied it will
* Make sure the files.xml rules are executed.
* Improve the formatting of errors found by filesXmlAllFilesDescribedOnce