### PR TITLE
EASY-1603 Improved checks on files.xml in specs and easy-validate-dans-bag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
 jdk: oraclejdk8
+cache:
+  directories:
+    - "$HOME/.m2/repository"

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -307,11 +307,11 @@ package object metadata extends DebugEnhancedLogging {
         debug("Rule filesXmlFilesHaveOnlyAllowedNamespaces has been checked by files.xsd")
       } else {
         val fileChildren = xml \ "file" \ "_"
-        val hasOnlyDcTermsInFileElements = fileChildren.forall {
+        val hasOnlyAllowedNamespaces = fileChildren.forall {
           case n: Elem => allowedFilesXmlNamespaces contains xml.getNamespace(n.prefix)
           case _ => true // Don't check non-element nodes
         }
-        if (!hasOnlyDcTermsInFileElements) fail("files.xml: non-dcterms elements found in some file elements")
+        if (!hasOnlyAllowedNamespaces) fail("files.xml: non-dc/dcterms elements found in some file elements")
       }
     }
   }

--- a/src/test/resources/bags/filesxml-non-dct-child/bag-info.txt
+++ b/src/test/resources/bags/filesxml-non-dct-child/bag-info.txt
@@ -1,3 +1,3 @@
 Payload-Oxum: 0.2
-Bagging-Date: 2018-05-25
-Bag-Size: 2.6 KB
+Bagging-Date: 2018-06-22
+Bag-Size: 2.5 KB

--- a/src/test/resources/bags/filesxml-non-dct-child/metadata/files.xml
+++ b/src/test/resources/bags/filesxml-non-dct-child/metadata/files.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<files xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:dcterms="http://purl.org/dc/terms/">
+<files xmlns:dcterms="http://purl.org/dc/terms/">
     <file filepath="data/leeg.txt">
         <dcterms:format>text/plain</dcterms:format>
     </file>

--- a/src/test/resources/bags/filesxml-non-dct-child/tagmanifest-md5.txt
+++ b/src/test/resources/bags/filesxml-non-dct-child/tagmanifest-md5.txt
@@ -1,5 +1,5 @@
-d9cea46c9f353c2a2a39f49f5c160e8e  bag-info.txt
+24118872036745160dd9668b4ff780bb  bag-info.txt
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
 3ee420aa1b637e328e587385fad2bc73  manifest-md5.txt
 1a737353f1e92fc50c0ec0b5a9b87538  metadata/dataset.xml
-d1cbbe45c134d34260ae79c4aba25354  metadata/files.xml
+04dc927cfc87001e1e03eafe52c7a42e  metadata/files.xml

--- a/src/test/resources/bags/filesxml-non-file-element/bag-info.txt
+++ b/src/test/resources/bags/filesxml-non-file-element/bag-info.txt
@@ -1,3 +1,3 @@
 Payload-Oxum: 0.2
-Bagging-Date: 2018-05-25
-Bag-Size: 2.5 KB
+Bagging-Date: 2018-06-22
+Bag-Size: 2.4 KB

--- a/src/test/resources/bags/filesxml-non-file-element/metadata/files.xml
+++ b/src/test/resources/bags/filesxml-non-file-element/metadata/files.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<files xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:dcterms="http://purl.org/dc/terms/">
+<files xmlns:dcterms="http://purl.org/dc/terms/">
     <file filepath="data/leeg.txt">
         <dcterms:format>text/plain</dcterms:format>
     </file>

--- a/src/test/resources/bags/filesxml-non-file-element/tagmanifest-md5.txt
+++ b/src/test/resources/bags/filesxml-non-file-element/tagmanifest-md5.txt
@@ -1,5 +1,5 @@
-e6ce191b2d9b9b682d1febc6dcce2cb7  bag-info.txt
+94c078d3e6b096638a12efc834736d04  bag-info.txt
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
 3ee420aa1b637e328e587385fad2bc73  manifest-md5.txt
 1a737353f1e92fc50c0ec0b5a9b87538  metadata/dataset.xml
-5271ad15eb65b316d3612df15fabf73e  metadata/files.xml
+2589506b19dfabd88d6ef6ce74ce7210  metadata/files.xml

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -236,7 +236,7 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
     testRuleViolation(
       rule = filesXmlFilesHaveOnlyAllowedNamespaces,
       inputBag = "filesxml-non-dct-child",
-      includedInErrorMsg = "non-dcterms elements found in some file elements"
+      includedInErrorMsg = "non-dc/dcterms elements found in some file elements"
     )
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -194,7 +194,7 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       includedInErrorMsg = "document element must be 'files'")
   }
 
-  "filesXmlHasOnlyFiles" should "fail if files.xml/files has non-file child" in {
+  "filesXmlHasOnlyFiles" should "fail if files.xml/files has non-file child and files.xsd namespace has been declared" in {
     testRuleViolation(
       rule = filesXmlHasOnlyFiles,
       inputBag = "filesxml-non-file-element",
@@ -232,7 +232,7 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
     )
   }
 
-  "filesXmlFilesHaveOnlyDcTerms" should "fail if there is a file element with a non dct child" in {
+  "filesXmlFilesHaveOnlyDcTerms" should "fail if there is a file element with a non dct child and files.xsd namespace has been declared" in {
     testRuleViolation(
       rule = filesXmlFilesHaveOnlyAllowedNamespaces,
       inputBag = "filesxml-non-dct-child",


### PR DESCRIPTION
Fixes EASY-1603

#### When applied it will
* Implement the rules specified in https://github.com/DANS-KNAW/easy-specs/pull/53

- [x] Find out if we need to update `files.xsd` or roll back (part of) this PR. The check on there not being any alien elements under `file` elements does *not* seem to be covered by the XSD - see the failing unit tests.


@DANS-KNAW/easy for review.