### PR TITLE
EASY-1588: A duplicate NumberedRule

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -68,8 +68,8 @@ object ProfileVersion0 {
     NumberedRule("3.1.7", pointsHaveAtLeastTwoValues, dependsOn = Some("3.1.1")),
 
     // files.xml
-    NumberedRule("3.2.1", filesXmlConformsToSchemaIfFilesNamespaceDeclared(xmlValidators("files.xml")), dependsOn = Some("2.2")),
-    NumberedRule("3.2.2", filesXmlHasDocumentElementFiles, dependsOn = Some("2.2")),
+    NumberedRule("3.2.1", filesXmlConformsToSchemaIfFilesNamespaceDeclared(xmlValidators("files.xml")), dependsOn = Some("2.3")),
+    NumberedRule("3.2.2", filesXmlHasDocumentElementFiles, dependsOn = Some("2.3")),
     NumberedRule("3.2.3", filesXmlHasOnlyFiles, dependsOn = Some("3.2.2")),
 
     NumberedRule("3.2.4", filesXmlFileElementsAllHaveFilepathAttribute, dependsOn = Some("3.2.3")),

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -54,8 +54,7 @@ object ProfileVersion0 {
     // STRUCTURAL
     NumberedRule("2.1", containsDir(Paths.get("metadata"))),
     NumberedRule("2.2", containsFile(Paths.get("metadata/dataset.xml")), dependsOn = Some("2.1")),
-    NumberedRule("2.2", containsFile(Paths.get("metadata/files.xml")), dependsOn = Some("2.1")),
-    // 2.3 does not state restrictions, so it does not need checking
+    NumberedRule("2.3", containsFile(Paths.get("metadata/files.xml")), dependsOn = Some("2.1")),
     NumberedRule("2.5", containsNothingElseThan(Paths.get("metadata"), Seq("dataset.xml", "files.xml", "agreements.xml")), dependsOn = Some("2.1")),
 
     // METADATA


### PR DESCRIPTION
Fixes EASY-1588

#### When applied it will
* solve the problem of incorrect error message when no dataset.xml in the bag
* 
* 

- [ ] Implement the solution as discussed off-line: use `(a)`, `(b)` etc for parts of rules. Also update Profile documents.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
