### PR TITLE
EASY-1704 Implement rule dataset.xml must contain DOI (3.1.3)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -65,6 +65,7 @@ object ProfileVersion0 {
     // dataset.xml
     NumberedRule("3.1.1", xmlFileConformsToSchema(Paths.get("metadata/dataset.xml"), "DANS dataset metadata schema", xmlValidators("dataset.xml")), dependsOn = List("2.2(a)")),
     NumberedRule("3.1.2", ddmMayContainDctermsLicenseFromList(allowedLicences), dependsOn = List("3.1.1")),
+    NumberedRule("3.1.3", ddmContainsValidDoiIdentifier, AIP, dependsOn = List("3.1.1")),
     NumberedRule("3.1.4", ddmDaisAreValid, dependsOn = List("3.1.1")),
     NumberedRule("3.1.5", ddmGmlPolygonPosListIsWellFormed, dependsOn = List("3.1.1")),
     NumberedRule("3.1.6", polygonsInSameMultiSurfaceHaveSameSrsName, dependsOn = List("3.1.1")),

--- a/src/test/resources/bags/ddm-correct-doi/bag-info.txt
+++ b/src/test/resources/bags/ddm-correct-doi/bag-info.txt
@@ -1,0 +1,4 @@
+Payload-Oxum: 48.2
+Bagging-Date: 2018-05-25
+Bag-Size: 5.8 KB
+Created: 2015-05-19T00:00:00.000+02:00

--- a/src/test/resources/bags/ddm-correct-doi/bagit.txt
+++ b/src/test/resources/bags/ddm-correct-doi/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-correct-doi/data/ruimtereis01_verklaring.txt
+++ b/src/test/resources/bags/ddm-correct-doi/data/ruimtereis01_verklaring.txt
@@ -1,0 +1,1 @@
+verklaring van goed gedrag

--- a/src/test/resources/bags/ddm-correct-doi/data/secret.txt
+++ b/src/test/resources/bags/ddm-correct-doi/data/secret.txt
@@ -1,0 +1,1 @@
+don't tell anybody!!!

--- a/src/test/resources/bags/ddm-correct-doi/manifest-sha1.txt
+++ b/src/test/resources/bags/ddm-correct-doi/manifest-sha1.txt
@@ -1,0 +1,2 @@
+11f3753c1ce7454931f667e7ccd44c2ae4798fe1  data/ruimtereis01_verklaring.txt
+fbd429500abb7a8ed309f3ccbec920369d2c77cb  data/secret.txt

--- a/src/test/resources/bags/ddm-correct-doi/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-correct-doi/metadata/dataset.xml
@@ -34,6 +34,6 @@
         <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
         <dcterms:rightsHolder>Vrije Universiteit Amsterdam</dcterms:rightsHolder>
         <dcterms:identifier xsi:type="id-type:DOI">10.1234/fantasy-doi-id</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:DOI">https://doi.org/10.1234.567/issn-987-654</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">10.1234.567/issn-987-654</dcterms:identifier>
     </ddm:dcmiMetadata>
 </ddm:DDM>

--- a/src/test/resources/bags/ddm-correct-doi/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-correct-doi/metadata/dataset.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd">
+    <ddm:profile>
+        <dc:title>PAN-00008136 - knobbed sickle</dc:title>
+        <dcterms:description xml:lang="en">This find is registered at Portable Antiquities of the Netherlands with number PAN-00008136</dcterms:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:organization>
+                <dcx-dai:name xml:lang="en">Portable Antiquities of the Netherlands</dcx-dai:name>
+                <dcx-dai:role>DataCurator</dcx-dai:role>
+            </dcx-dai:organization>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2017-10-23T17:06:11+02:00</ddm:created>
+        <ddm:available>2017-10-23T17:06:11+02:00</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dcterms:spatial>Overbetuwe</dcterms:spatial>
+        <dcterms:isFormatOf>PAN-00008136</dcterms:isFormatOf>
+        <ddm:references href="https://www.portable-antiquities.nl/pan/#/object/public/8136">Portable Antiquities of The Netherlands</ddm:references>
+        <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="https://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
+        <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
+        <dc:subject>metaal</dc:subject>
+        <dc:subject>koperlegering</dc:subject>
+        <dcterms:identifier>PAN-00008136</dcterms:identifier>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSMB</dcterms:temporal>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSL</dcterms:temporal>
+        <dcterms:temporal>-1500 until -800</dcterms:temporal>
+        <dc:language xsi:type="dcterms:ISO639-2">eng</dc:language>
+        <dc:publisher xmlns:dc="http://purl.org/dc/terms/">DANS/KNAW</dc:publisher>
+        <dc:type xsi:type="dcterms:DCMIType" xmlns:dc="http://purl.org/dc/terms/">Dataset</dc:type>
+        <dc:format xsi:type="dcterms:IMT">image/jpeg</dc:format>
+        <dc:format xsi:type="dcterms:IMT">application/xml</dc:format>
+        <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
+        <dcterms:rightsHolder>Vrije Universiteit Amsterdam</dcterms:rightsHolder>
+        <dcterms:identifier xsi:type="id-type:DOI">10.1234/fantasy-doi-id</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">https://doi.org/10.1234.567/issn-987-654</dcterms:identifier>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-correct-doi/metadata/files.xml
+++ b/src/test/resources/bags/ddm-correct-doi/metadata/files.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+    <file filepath="data/ruimtereis01_verklaring.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+    <file filepath="data/secret.txt">
+        <dcterms:format>text/plain</dcterms:format>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>NONE</visibleToRights>
+    </file>
+</files>

--- a/src/test/resources/bags/ddm-correct-doi/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-correct-doi/tagmanifest-sha1.txt
@@ -1,0 +1,5 @@
+fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
+ccd06719e599b39c328ae5c1016bc362443783b8  metadata/dataset.xml
+e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
+37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
+a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/resources/bags/ddm-correct-doi/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-correct-doi/tagmanifest-sha1.txt
@@ -1,5 +1,5 @@
 fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
-ccd06719e599b39c328ae5c1016bc362443783b8  metadata/dataset.xml
+72dadf35c09b1bbc862c5f33c0ff403491c19c5f  metadata/dataset.xml
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
 37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
 a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/resources/bags/ddm-incorrect-doi/bag-info.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/bag-info.txt
@@ -1,0 +1,4 @@
+Payload-Oxum: 48.2
+Bagging-Date: 2018-05-25
+Bag-Size: 5.8 KB
+Created: 2015-05-19T00:00:00.000+02:00

--- a/src/test/resources/bags/ddm-incorrect-doi/bagit.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-incorrect-doi/data/ruimtereis01_verklaring.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/data/ruimtereis01_verklaring.txt
@@ -1,0 +1,1 @@
+verklaring van goed gedrag

--- a/src/test/resources/bags/ddm-incorrect-doi/data/secret.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/data/secret.txt
@@ -1,0 +1,1 @@
+don't tell anybody!!!

--- a/src/test/resources/bags/ddm-incorrect-doi/manifest-sha1.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/manifest-sha1.txt
@@ -1,0 +1,2 @@
+11f3753c1ce7454931f667e7ccd44c2ae4798fe1  data/ruimtereis01_verklaring.txt
+fbd429500abb7a8ed309f3ccbec920369d2c77cb  data/secret.txt

--- a/src/test/resources/bags/ddm-incorrect-doi/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-incorrect-doi/metadata/dataset.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd">
+    <ddm:profile>
+        <dc:title>PAN-00008136 - knobbed sickle</dc:title>
+        <dcterms:description xml:lang="en">This find is registered at Portable Antiquities of the Netherlands with number PAN-00008136</dcterms:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:organization>
+                <dcx-dai:name xml:lang="en">Portable Antiquities of the Netherlands</dcx-dai:name>
+                <dcx-dai:role>DataCurator</dcx-dai:role>
+            </dcx-dai:organization>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2017-10-23T17:06:11+02:00</ddm:created>
+        <ddm:available>2017-10-23T17:06:11+02:00</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dcterms:spatial>Overbetuwe</dcterms:spatial>
+        <dcterms:isFormatOf>PAN-00008136</dcterms:isFormatOf>
+        <ddm:references href="https://www.portable-antiquities.nl/pan/#/object/public/8136">Portable Antiquities of The Netherlands</ddm:references>
+        <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="https://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
+        <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
+        <dc:subject>metaal</dc:subject>
+        <dc:subject>koperlegering</dc:subject>
+        <dcterms:identifier>PAN-00008136</dcterms:identifier>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSMB</dcterms:temporal>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSL</dcterms:temporal>
+        <dcterms:temporal>-1500 until -800</dcterms:temporal>
+        <dc:language xsi:type="dcterms:ISO639-2">eng</dc:language>
+        <dc:publisher xmlns:dc="http://purl.org/dc/terms/">DANS/KNAW</dc:publisher>
+        <dc:type xsi:type="dcterms:DCMIType" xmlns:dc="http://purl.org/dc/terms/">Dataset</dc:type>
+        <dc:format xsi:type="dcterms:IMT">image/jpeg</dc:format>
+        <dc:format xsi:type="dcterms:IMT">application/xml</dc:format>
+        <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
+        <dcterms:rightsHolder>Vrije Universiteit Amsterdam</dcterms:rightsHolder>
+        <dcterms:identifier xsi:type="id-type:DOI">10.1234/fantasy-doi-id</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">11.1234/fantasy-doi-id</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">10/1234/fantasy-doi-id</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">10.1234.fantasy-doi-id</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">http://doi.org/10.1234.567/issn-987-654</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">https://doi/10.1234.567/issn-987-654</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">https://doi.org/10.1234:567/issn-987-654</dcterms:identifier>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-incorrect-doi/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-incorrect-doi/metadata/dataset.xml
@@ -38,7 +38,6 @@
         <dcterms:identifier xsi:type="id-type:DOI">10/1234/fantasy-doi-id</dcterms:identifier>
         <dcterms:identifier xsi:type="id-type:DOI">10.1234.fantasy-doi-id</dcterms:identifier>
         <dcterms:identifier xsi:type="id-type:DOI">http://doi.org/10.1234.567/issn-987-654</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:DOI">https://doi/10.1234.567/issn-987-654</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:DOI">https://doi.org/10.1234:567/issn-987-654</dcterms:identifier>
+        <dcterms:identifier xsi:type="id-type:DOI">https://doi.org/10.1234.567/issn-987-654</dcterms:identifier>
     </ddm:dcmiMetadata>
 </ddm:DDM>

--- a/src/test/resources/bags/ddm-incorrect-doi/metadata/files.xml
+++ b/src/test/resources/bags/ddm-incorrect-doi/metadata/files.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+    <file filepath="data/ruimtereis01_verklaring.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+    <file filepath="data/secret.txt">
+        <dcterms:format>text/plain</dcterms:format>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>NONE</visibleToRights>
+    </file>
+</files>

--- a/src/test/resources/bags/ddm-incorrect-doi/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/tagmanifest-sha1.txt
@@ -1,5 +1,5 @@
 fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
-cbea9702955f3cee9976bd72373f4c1395682cef  metadata/dataset.xml
+c7c41d35b3910ea84c2a7764cd134ea5b1e73ff1  metadata/dataset.xml
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
 37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
 a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/resources/bags/ddm-incorrect-doi/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-incorrect-doi/tagmanifest-sha1.txt
@@ -1,0 +1,5 @@
+fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
+cbea9702955f3cee9976bd72373f4c1395682cef  metadata/dataset.xml
+e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
+37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
+a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/resources/bags/ddm-missing-doi/bag-info.txt
+++ b/src/test/resources/bags/ddm-missing-doi/bag-info.txt
@@ -1,0 +1,4 @@
+Payload-Oxum: 48.2
+Bagging-Date: 2018-05-25
+Bag-Size: 5.8 KB
+Created: 2015-05-19T00:00:00.000+02:00

--- a/src/test/resources/bags/ddm-missing-doi/bagit.txt
+++ b/src/test/resources/bags/ddm-missing-doi/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-missing-doi/data/ruimtereis01_verklaring.txt
+++ b/src/test/resources/bags/ddm-missing-doi/data/ruimtereis01_verklaring.txt
@@ -1,0 +1,1 @@
+verklaring van goed gedrag

--- a/src/test/resources/bags/ddm-missing-doi/data/secret.txt
+++ b/src/test/resources/bags/ddm-missing-doi/data/secret.txt
@@ -1,0 +1,1 @@
+don't tell anybody!!!

--- a/src/test/resources/bags/ddm-missing-doi/manifest-sha1.txt
+++ b/src/test/resources/bags/ddm-missing-doi/manifest-sha1.txt
@@ -1,0 +1,2 @@
+11f3753c1ce7454931f667e7ccd44c2ae4798fe1  data/ruimtereis01_verklaring.txt
+fbd429500abb7a8ed309f3ccbec920369d2c77cb  data/secret.txt

--- a/src/test/resources/bags/ddm-missing-doi/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-missing-doi/metadata/dataset.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd">
+    <ddm:profile>
+        <dc:title>PAN-00008136 - knobbed sickle</dc:title>
+        <dcterms:description xml:lang="en">This find is registered at Portable Antiquities of the Netherlands with number PAN-00008136</dcterms:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:organization>
+                <dcx-dai:name xml:lang="en">Portable Antiquities of the Netherlands</dcx-dai:name>
+                <dcx-dai:role>DataCurator</dcx-dai:role>
+            </dcx-dai:organization>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2017-10-23T17:06:11+02:00</ddm:created>
+        <ddm:available>2017-10-23T17:06:11+02:00</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dcterms:spatial>Overbetuwe</dcterms:spatial>
+        <dcterms:isFormatOf>PAN-00008136</dcterms:isFormatOf>
+        <ddm:references href="https://www.portable-antiquities.nl/pan/#/object/public/8136">Portable Antiquities of The Netherlands</ddm:references>
+        <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="https://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
+        <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
+        <dc:subject>metaal</dc:subject>
+        <dc:subject>koperlegering</dc:subject>
+        <dcterms:identifier>PAN-00008136</dcterms:identifier>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSMB</dcterms:temporal>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSL</dcterms:temporal>
+        <dcterms:temporal>-1500 until -800</dcterms:temporal>
+        <dc:language xsi:type="dcterms:ISO639-2">eng</dc:language>
+        <dc:publisher xmlns:dc="http://purl.org/dc/terms/">DANS/KNAW</dc:publisher>
+        <dc:type xsi:type="dcterms:DCMIType" xmlns:dc="http://purl.org/dc/terms/">Dataset</dc:type>
+        <dc:format xsi:type="dcterms:IMT">image/jpeg</dc:format>
+        <dc:format xsi:type="dcterms:IMT">application/xml</dc:format>
+        <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
+        <dcterms:rightsHolder>Vrije Universiteit Amsterdam</dcterms:rightsHolder>
+        <dcterms:identifier xsi:type="id-type:NOT-DOI">10.1234/fantasy-doi-id</dcterms:identifier>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-missing-doi/metadata/files.xml
+++ b/src/test/resources/bags/ddm-missing-doi/metadata/files.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+    <file filepath="data/ruimtereis01_verklaring.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+    <file filepath="data/secret.txt">
+        <dcterms:format>text/plain</dcterms:format>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>NONE</visibleToRights>
+    </file>
+</files>

--- a/src/test/resources/bags/ddm-missing-doi/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-missing-doi/tagmanifest-sha1.txt
@@ -1,0 +1,5 @@
+fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
+11a97de80d8d387ab2682d8d447d408e7d796197  metadata/dataset.xml
+e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
+37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
+a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -125,6 +125,26 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       inputBag = "ddm-correct-dai")
   }
 
+  "ddmContainsValidDoiIdentifier" should "succeed if one or more DOIs are present and they are valid" in {
+    testRuleSuccess(
+      rule = ddmContainsValidDoiIdentifier,
+      inputBag = "ddm-correct-doi")
+  }
+
+  it should "fail if there is no DOI-identifier" in {
+    testRuleViolation(
+      rule = ddmContainsValidDoiIdentifier,
+      inputBag = "ddm-missing-doi",
+      includedInErrorMsg = "DOI identifier is missing")
+  }
+
+  it should "report invalid DOI-identifiers" in {
+    testRuleViolation(
+      rule = ddmContainsValidDoiIdentifier,
+      inputBag = "ddm-incorrect-doi",
+      includedInErrorMsg = "Invalid DOIs: 11.1234/fantasy-doi-id, 10/1234/fantasy-doi-id, 10.1234.fantasy-doi-id, http://doi.org/10.1234.567/issn-987-654, https://doi/10.1234.567/issn-987-654, https://doi.org/10.1234:567/issn-987-654")
+  }
+
   "ddmGmlPolygonPosListIsWellFormed" should "report error if odd number of values in posList" in {
     testRuleViolation(
       rule = ddmGmlPolygonPosListIsWellFormed,

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -142,7 +142,7 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
     testRuleViolation(
       rule = ddmContainsValidDoiIdentifier,
       inputBag = "ddm-incorrect-doi",
-      includedInErrorMsg = "Invalid DOIs: 11.1234/fantasy-doi-id, 10/1234/fantasy-doi-id, 10.1234.fantasy-doi-id, http://doi.org/10.1234.567/issn-987-654, https://doi/10.1234.567/issn-987-654, https://doi.org/10.1234:567/issn-987-654")
+      includedInErrorMsg = "Invalid DOIs: 11.1234/fantasy-doi-id, 10/1234/fantasy-doi-id, 10.1234.fantasy-doi-id, http://doi.org/10.1234.567/issn-987-654, https://doi.org/10.1234.567/issn-987-654")
   }
 
   "ddmGmlPolygonPosListIsWellFormed" should "report error if odd number of values in posList" in {


### PR DESCRIPTION
Fixes EASY-1704

#### When applied it will
* check that for an AIP there is at last one DOI identifier defined in dataset.xml
* check that all DOIs are valid
* report invalid DOIs

Note: this is not yet implemented for ProfileVersion1 because all metadata checks are still missing.  We will make another issue to add all the metadata checks for version 1.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
