### PR TITLE
EASY-1731 easy-validate-dans-bag fails prematurely on malformed bag-info.txt

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagApp.scala
@@ -77,6 +77,6 @@ class EasyValidateDansBagApp(configuration: Configuration) extends DebugEnhanced
   val extractViolations: PartialFunction[Throwable, Try[Seq[(RuleNumber, String)]]] = {
     case x @ CompositeException(xs) =>
       if (xs.forall(_.isInstanceOf[RuleViolationException])) Try(xs.map { case RuleViolationException(nr, details) => (nr, details) })
-      else Failure(new IllegalStateException("Rule violations mixed with fatal exceptions. This should not be possible!!!"))
+      else Failure(new IllegalStateException("Rule violations mixed with fatal exceptions. This should not be possible!!!", x))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagApp.scala
@@ -77,6 +77,6 @@ class EasyValidateDansBagApp(configuration: Configuration) extends DebugEnhanced
   val extractViolations: PartialFunction[Throwable, Try[Seq[(RuleNumber, String)]]] = {
     case x @ CompositeException(xs) =>
       if (xs.forall(_.isInstanceOf[RuleViolationException])) Try(xs.map { case RuleViolationException(nr, details) => (nr, details) })
-      else Failure(x) // If there are other exceptions, just generate a fatal exception; let the caller sort out the more serious problems first.
+      else Failure(new IllegalStateException("Rule violations mixed with fatal exceptions. This should not be possible!!!"))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -37,7 +37,7 @@ object ProfileVersion0 {
     NumberedRule("1.1.1(datadir)", containsDir(Paths.get("data"))),
 
     // bag-info.txt
-    NumberedRule("1.2.1", containsFile(Paths.get("bag-info.txt"))),
+    NumberedRule("1.2.1", bagInfoExistsAndIsWellFormed),
     NumberedRule("1.2.2(a)", bagInfoContainsAtMostOneOf("BagIt-Profile-Version"), dependsOn = List("1.2.1")),
     NumberedRule("1.2.2(b)", bagInfoElementIfExistsHasValue("BagIt-Profile-Version", versionNumber.toString), dependsOn = List("1.2.2(a)")),
     NumberedRule("1.2.3(a)", bagInfoContainsAtMostOneOf("BagIt-Profile-URI"), dependsOn = List("1.2.1")),
@@ -50,7 +50,7 @@ object ProfileVersion0 {
 
     // Manifests
     NumberedRule("1.3.1(a)", containsFile(Paths.get("manifest-sha1.txt"))),
-    NumberedRule("1.3.1(b)", bagShaPayloadManifestContainsAllPayloadFiles, dependsOn = List("1.3.1(a)")),
+    NumberedRule("1.3.1(b)", bagShaPayloadManifestContainsAllPayloadFiles, dependsOn = List("1.2.1", "1.3.1(a)")),
     // 1.3.2 does not state restrictions, so it does not need checking
 
     // STRUCTURAL

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/bagit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/bagit/package.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.validatebag.rules
 
-import java.nio.file.NoSuchFileException
+import java.nio.file.{ NoSuchFileException, Paths }
 
 import gov.loc.repository.bagit.domain.Bag
 import gov.loc.repository.bagit.exceptions._
@@ -83,6 +83,16 @@ package object bagit extends DebugEnhancedLogging {
           case cause: InvalidBagitFileFormatException => failBecauseInvalid(cause)
         }
     }
+  }
+
+  def bagInfoExistsAndIsWellFormed(t: TargetBag): Try[Unit] = {
+    trace(())
+    for {
+      _ <- containsFile(Paths.get("bag-info.txt"))(t)
+      _ <- t.tryBag.recoverWith {
+        case e: InvalidBagMetadataException => Try(fail(s"bag-info.txt exists but is malformed: ${ e.getMessage }"))
+      }
+    } yield ()
   }
 
   def bagIsVirtuallyValid(t: TargetBag): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
@@ -31,18 +31,6 @@ package object structural extends DebugEnhancedLogging {
       fail(s"Mandatory directory '$d' not found in bag.")
   }
 
-  def containsFile(f: Path)(t: TargetBag) = Try {
-    trace(f)
-    require(!f.isAbsolute, s"File $f must be a relative path")
-    val fileToCheck = t.bagDir / f.toString
-    if (!fileToCheck.isRegularFile)
-      fail(s"Mandatory file '$f' not found in bag.")
-    val relativeRealPath = t.bagDir.path.relativize(fileToCheck.path.toRealPath())
-    val relativeRequiredPath = t.bagDir.path.relativize(fileToCheck.path)
-    if (relativeRealPath != relativeRequiredPath)
-      fail(s"Path name differs in case; found: $relativeRealPath, required: $relativeRequiredPath")
-  }
-
   def doesNotContainFile(f: Path)(t: TargetBag) = Try {
     trace(f)
     require(!f.isAbsolute, s"File $f must be a relative path")

--- a/src/test/resources/bags/baginfo-added-empty-line/bag-info.txt
+++ b/src/test/resources/bags/baginfo-added-empty-line/bag-info.txt
@@ -1,0 +1,5 @@
+Payload-Oxum: 0.1
+Bagging-Date: 2018-03-15
+Bag-Size: 0.3 KB
+Created: 2015-05-19T00:00:00.000+02:00
+

--- a/src/test/resources/bags/baginfo-added-empty-line/bagit.txt
+++ b/src/test/resources/bags/baginfo-added-empty-line/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/baginfo-added-empty-line/manifest-md5.txt
+++ b/src/test/resources/bags/baginfo-added-empty-line/manifest-md5.txt
@@ -1,0 +1,1 @@
+d41d8cd98f00b204e9800998ecf8427e  data/leeg.txt

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/RulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/RulesSpec.scala
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.validatebag.rules
+
+import java.nio.file.Paths
+
+import nl.knaw.dans.easy.validatebag.TestSupportFixture
+
+class RulesSpec extends TestSupportFixture {
+
+  "containsFile" should "fail if file name is different case" in {
+    /*
+     * This test will fail for different reasons on case sensitive and case insensitive file systems respectively. Hence the regex with two
+     * alternative error messages.
+     */
+    testRuleViolationRegex(containsFile(Paths.get("Metadata")), "metadata-correct", "(not found in bag|differs in case)".r)
+  }
+
+  it should "fail if target is a directory instead of a file" in {
+    testRuleViolation(containsFile(Paths.get("data")), "generic-minimal", "not found in bag")
+  }
+
+  it should "succeed if file exists" in {
+    testRuleSuccess(containsFile(Paths.get("bagit.txt")), "metadata-correct")
+  }
+
+}

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/bagit/BagInfoTxtRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/bagit/BagInfoTxtRulesSpec.scala
@@ -18,6 +18,19 @@ package nl.knaw.dans.easy.validatebag.rules.bagit
 import nl.knaw.dans.easy.validatebag.TestSupportFixture
 
 class BagInfoTxtRulesSpec extends TestSupportFixture {
+
+  "bagInfoExistsAndIsWellFormed" should "fail if bag-info.txt does not exist" in {
+    testRuleViolation(rule = bagInfoExistsAndIsWellFormed, inputBag = "baginfo-missing-bag-infotxt", includedInErrorMsg = "not found in bag")
+  }
+
+  it should "fail if bag-info.txt contains an empty line" in {
+    testRuleViolation(rule = bagInfoExistsAndIsWellFormed, inputBag = "baginfo-added-empty-line", includedInErrorMsg = "exists but is malformed", doubleCheckBagItValidity = false)
+  }
+
+  it should "Succeed if it exists and is well-formed" in {
+    testRuleSuccess(rule = bagInfoExistsAndIsWellFormed, inputBag = "generic-minimal")
+  }
+
   "bagInfoContainsAtMostOneOf(\"ELEMENT\")" should "fail if bag-info.txt contains two ELEMENT elements" in {
     testRuleViolation(bagInfoContainsAtMostOneOf("ELEMENT"),
       inputBag = "baginfo-two-elements-of-same-key",

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
@@ -18,7 +18,6 @@ package nl.knaw.dans.easy.validatebag.rules.structural
 import java.nio.file.Paths
 
 import nl.knaw.dans.easy.validatebag.TestSupportFixture
-import nl.knaw.dans.easy.validatebag.rules.containsFile
 
 class StructuralRulesSpec extends TestSupportFixture {
 
@@ -32,22 +31,6 @@ class StructuralRulesSpec extends TestSupportFixture {
 
   it should "succeed if directory exists" in {
     testRuleSuccess(containsDir(Paths.get("metadata")), "metadata-correct")
-  }
-
-  "containsFile" should "fail if file name is different case" in {
-    /*
-     * This test will fail for different reasons on case sensitive and case insensitive file systems respectively. Hence the regex with two
-     * alternative error messages.
-     */
-    testRuleViolationRegex(containsFile(Paths.get("Metadata")), "metadata-correct", "(not found in bag|differs in case)".r)
-  }
-
-  it should "fail if target is a directory instead of a file" in {
-    testRuleViolation(containsFile(Paths.get("data")), "generic-minimal", "not found in bag")
-  }
-
-  it should "succeed if file exists" in {
-    testRuleSuccess(containsFile(Paths.get("bagit.txt")), "metadata-correct")
   }
 
   "containsNothingElseThan" should "fail if other file is present" in {

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.validatebag.rules.structural
 import java.nio.file.Paths
 
 import nl.knaw.dans.easy.validatebag.TestSupportFixture
+import nl.knaw.dans.easy.validatebag.rules.containsFile
 
 class StructuralRulesSpec extends TestSupportFixture {
 


### PR DESCRIPTION
Fixes EASY-1731

#### When applied it will
* Make sure that when unable to get the declared profile version because of a malformed `bag-info.txt` the default version `0` is used.
* Report a malformed `bag-info.txt`
* Not trigger a fatal error when a `bag-info.txt` is malformed, by skipping rules that try to read the bag.
* Fail fast when a fatal error is encountered, so that a clear exception is reported in the logs (contributed by @rvanheest).

#### Where should the reviewer @DANS-KNAW/easy start?
* https://github.com/DANS-KNAW/easy-validate-dans-bag/compare/master...janvanmansum:EASY-1731?expand=1#diff-993c8fb41fa8a517f4d7ed0cfaa55897R88
* https://github.com/DANS-KNAW/easy-validate-dans-bag/compare/master...janvanmansum:EASY-1731?expand=1#diff-3df2b5375972cc5c0725c90193f7a3a4R118

#### How should this be manually tested?
For example by an example deposit with the sample bag from the issue.

- [x] Test on deasy
