### PR TITLE
only fail with archis identifier if actually something incorrect was found

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -274,7 +274,7 @@ package object metadata extends DebugEnhancedLogging {
       ddm <- t.tryDdm
       identifiers = getArchisIdentifiers(ddm)
       validationResult = identifiers.map(validateArchisIdentifier)
-      _ = fail(formatInvalidArchisIdentifiers(validationResult).mkString("\n"))
+      _ = if (validationResult.nonEmpty) fail(formatInvalidArchisIdentifiers(validationResult).mkString("\n"))
     } yield ()
   }
 


### PR DESCRIPTION
~~Fixes EASY-~~

#### When applied it will
* only fail on the archis identifier rule when a violation is found

@DANS-KNAW/easy for review