### PR TITLE
EASY-1820 : increment version of agreements.xsd due to rename

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -8,7 +8,7 @@ daemon.http.port=20180
 #
 schemas.ddm=https://easy.dans.knaw.nl/schemas/md/2018/03/ddm.xsd
 schemas.files=https://easy.dans.knaw.nl/schemas/bag/metadata/files/2018/04/files.xsd
-schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/05/agreements.xsd
+schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/12/agreements.xsd
 
 #
 # Bag store service to validate baq-sequence-related rules against.

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,7 +1,7 @@
 daemon.http.port=20180
 schemas.ddm=https://easy.dans.knaw.nl/schemas/md/2018/03/ddm.xsd
 schemas.files=https://easy.dans.knaw.nl/schemas/bag/metadata/files/2018/04/files.xsd
-schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/05/agreements.xsd
+schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/12/agreements.xsd
 bagstore-service.base-url=http://deasy.dans.knaw.nl:20110/
 bagstore-service.connection-timeout-milliseconds=5000
 bagstore-service.read-timeout-milliseconds=5000


### PR DESCRIPTION
Fixes EASY-1820 : increment version of agreements.xsd due to rename (licenseAgrement -> depositAgrement)

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
deploy together with:
* https://github.com/DANS-KNAW/easy-specs/pull/63
* https://github.com/DANS-KNAW/easy-deposit-api/pull/102
