### PR TITLE
EASY-1882: no error when a MultiSurface doesn't have any polygons

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -239,9 +239,9 @@ package object metadata extends DebugEnhancedLogging {
     (ddm \\ "MultiSurface").filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Elem]]
   }
 
-  private def validateMultiSurface(ms: Elem) = {
+  private def validateMultiSurface(ms: Elem): Try[Unit] = {
     val polygons = getPolygons(ms)
-    if (polygons.map(_.attribute("srsName").map(_.text)).distinct.size == 1) Success(())
+    if (polygons.isEmpty || polygons.flatMap(_.attribute("srsName").map(_.text)).distinct.size <= 1) Success(())
     else Try(fail("Found MultiSurface element containing polygons with different srsNames"))
   }
 

--- a/src/test/resources/bags/ddm-empty-multisurface/bag-info.txt
+++ b/src/test/resources/bags/ddm-empty-multisurface/bag-info.txt
@@ -1,0 +1,4 @@
+Payload-Oxum: 48.2
+Bagging-Date: 2018-05-25
+Bag-Size: 5.8 KB
+Created: 2015-05-19T00:00:00.000+02:00

--- a/src/test/resources/bags/ddm-empty-multisurface/bagit.txt
+++ b/src/test/resources/bags/ddm-empty-multisurface/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-empty-multisurface/data/ruimtereis01_verklaring.txt
+++ b/src/test/resources/bags/ddm-empty-multisurface/data/ruimtereis01_verklaring.txt
@@ -1,0 +1,1 @@
+verklaring van goed gedrag

--- a/src/test/resources/bags/ddm-empty-multisurface/data/secret.txt
+++ b/src/test/resources/bags/ddm-empty-multisurface/data/secret.txt
@@ -1,0 +1,1 @@
+don't tell anybody!!!

--- a/src/test/resources/bags/ddm-empty-multisurface/manifest-sha1.txt
+++ b/src/test/resources/bags/ddm-empty-multisurface/manifest-sha1.txt
@@ -1,0 +1,2 @@
+11f3753c1ce7454931f667e7ccd44c2ae4798fe1  data/ruimtereis01_verklaring.txt
+fbd429500abb7a8ed309f3ccbec920369d2c77cb  data/secret.txt

--- a/src/test/resources/bags/ddm-empty-multisurface/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-empty-multisurface/metadata/dataset.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd">
+    <ddm:profile>
+        <dc:title>PAN-00008136 - knobbed sickle</dc:title>
+        <dcterms:description xml:lang="en">This find is registered at Portable Antiquities of the Netherlands with number PAN-00008136</dcterms:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:organization>
+                <dcx-dai:name xml:lang="en">Portable Antiquities of the Netherlands</dcx-dai:name>
+                <dcx-dai:role>DataCurator</dcx-dai:role>
+            </dcx-dai:organization>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2017-10-23T17:06:11+02:00</ddm:created>
+        <ddm:available>2017-10-23T17:06:11+02:00</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dcx-gml:spatial>
+            <MultiSurface xmlns="http://www.opengis.net/gml">
+                <name>A surface with no polygons (VALID!)</name>
+            </MultiSurface>
+	</dcx-gml:spatial>
+        <dcterms:spatial>Overbetuwe</dcterms:spatial>
+        <dcterms:isFormatOf>PAN-00008136</dcterms:isFormatOf>
+        <ddm:references href="https://www.portable-antiquities.nl/pan/#/object/public/8136">Portable Antiquities of The Netherlands</ddm:references>
+        <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="https://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
+        <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
+        <dc:subject>metaal</dc:subject>
+        <dc:subject>koperlegering</dc:subject>
+        <dcterms:identifier>PAN-00008136</dcterms:identifier>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSMB</dcterms:temporal>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSL</dcterms:temporal>
+        <dcterms:temporal>-1500 until -800</dcterms:temporal>
+        <dc:language xsi:type="dcterms:ISO639-2">eng</dc:language>
+        <dc:publisher xmlns:dc="http://purl.org/dc/terms/">DANS/KNAW</dc:publisher>
+        <dc:type xsi:type="dcterms:DCMIType" xmlns:dc="http://purl.org/dc/terms/">Dataset</dc:type>
+        <dc:format xsi:type="dcterms:IMT">image/jpeg</dc:format>
+        <dc:format xsi:type="dcterms:IMT">application/xml</dc:format>
+        <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
+        <dcterms:rightsHolder>Vrije Universiteit Amsterdam</dcterms:rightsHolder>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-empty-multisurface/metadata/files.xml
+++ b/src/test/resources/bags/ddm-empty-multisurface/metadata/files.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+    <file filepath="data/ruimtereis01_verklaring.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+    <file filepath="data/secret.txt">
+        <dcterms:format>text/plain</dcterms:format>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>NONE</visibleToRights>
+    </file>
+</files>

--- a/src/test/resources/bags/ddm-empty-multisurface/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-empty-multisurface/tagmanifest-sha1.txt
@@ -1,0 +1,5 @@
+fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
+5415872787834490570bd76857b074f61602daee  metadata/dataset.xml
+e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
+37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
+a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/resources/bags/ddm-no-srs-names/bag-info.txt
+++ b/src/test/resources/bags/ddm-no-srs-names/bag-info.txt
@@ -1,0 +1,4 @@
+Payload-Oxum: 48.2
+Bagging-Date: 2018-05-25
+Bag-Size: 5.8 KB
+Created: 2015-05-19T00:00:00.000+02:00

--- a/src/test/resources/bags/ddm-no-srs-names/bagit.txt
+++ b/src/test/resources/bags/ddm-no-srs-names/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-no-srs-names/data/ruimtereis01_verklaring.txt
+++ b/src/test/resources/bags/ddm-no-srs-names/data/ruimtereis01_verklaring.txt
@@ -1,0 +1,1 @@
+verklaring van goed gedrag

--- a/src/test/resources/bags/ddm-no-srs-names/data/secret.txt
+++ b/src/test/resources/bags/ddm-no-srs-names/data/secret.txt
@@ -1,0 +1,1 @@
+don't tell anybody!!!

--- a/src/test/resources/bags/ddm-no-srs-names/manifest-sha1.txt
+++ b/src/test/resources/bags/ddm-no-srs-names/manifest-sha1.txt
@@ -1,0 +1,2 @@
+11f3753c1ce7454931f667e7ccd44c2ae4798fe1  data/ruimtereis01_verklaring.txt
+fbd429500abb7a8ed309f3ccbec920369d2c77cb  data/secret.txt

--- a/src/test/resources/bags/ddm-no-srs-names/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-no-srs-names/metadata/dataset.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd">
+    <ddm:profile>
+        <dc:title>PAN-00008136 - knobbed sickle</dc:title>
+        <dcterms:description xml:lang="en">This find is registered at Portable Antiquities of the Netherlands with number PAN-00008136</dcterms:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:organization>
+                <dcx-dai:name xml:lang="en">Portable Antiquities of the Netherlands</dcx-dai:name>
+                <dcx-dai:role>DataCurator</dcx-dai:role>
+            </dcx-dai:organization>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2017-10-23T17:06:11+02:00</ddm:created>
+        <ddm:available>2017-10-23T17:06:11+02:00</ddm:available>
+        <ddm:audience>D37000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dcx-gml:spatial>
+            <MultiSurface xmlns="http://www.opengis.net/gml">
+                <name>A random surface with multiple polygons</name>
+                <surfaceMember>
+                    <Polygon>
+                        <description>A triangle between BP, De Horeca Academie en the railway station</description>
+                        <exterior>
+                            <LinearRing>
+                                <posList>52.079710 4.342778 52.079710 4.342778 52.07913 4.34332 52.079710 4.342778</posList>
+                            </LinearRing>
+                        </exterior>
+                    </Polygon>
+		        </surfaceMember>
+                <surfaceMember>
+                    <Polygon>
+                        <description>A triangle between BP, De Horeca Academie en the railway station</description>
+                        <exterior>
+                            <LinearRing>
+                                <posList>52.079710 4.342778 52.079710 4.342778 52.07913 4.34332 52.079710 4.342778</posList>
+                            </LinearRing>
+                        </exterior>
+                    </Polygon>
+		        </surfaceMember>
+            </MultiSurface>
+	</dcx-gml:spatial>
+        <dcterms:spatial>Overbetuwe</dcterms:spatial>
+        <dcterms:isFormatOf>PAN-00008136</dcterms:isFormatOf>
+        <ddm:references href="https://www.portable-antiquities.nl/pan/#/object/public/8136">Portable Antiquities of The Netherlands</ddm:references>
+        <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="https://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
+        <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
+        <dc:subject>metaal</dc:subject>
+        <dc:subject>koperlegering</dc:subject>
+        <dcterms:identifier>PAN-00008136</dcterms:identifier>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSMB</dcterms:temporal>
+        <dcterms:temporal xsi:type="abr:ABRperiode">BRONSL</dcterms:temporal>
+        <dcterms:temporal>-1500 until -800</dcterms:temporal>
+        <dc:language xsi:type="dcterms:ISO639-2">eng</dc:language>
+        <dc:publisher xmlns:dc="http://purl.org/dc/terms/">DANS/KNAW</dc:publisher>
+        <dc:type xsi:type="dcterms:DCMIType" xmlns:dc="http://purl.org/dc/terms/">Dataset</dc:type>
+        <dc:format xsi:type="dcterms:IMT">image/jpeg</dc:format>
+        <dc:format xsi:type="dcterms:IMT">application/xml</dc:format>
+        <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
+        <dcterms:rightsHolder>Vrije Universiteit Amsterdam</dcterms:rightsHolder>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-no-srs-names/metadata/files.xml
+++ b/src/test/resources/bags/ddm-no-srs-names/metadata/files.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+    <file filepath="data/ruimtereis01_verklaring.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+    <file filepath="data/secret.txt">
+        <dcterms:format>text/plain</dcterms:format>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>NONE</visibleToRights>
+    </file>
+</files>

--- a/src/test/resources/bags/ddm-no-srs-names/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-no-srs-names/tagmanifest-sha1.txt
@@ -1,0 +1,5 @@
+fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
+e2fb532780b33709c5cbc9d30848639be7808fd5  metadata/dataset.xml
+e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
+37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
+a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -179,6 +179,18 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       includedInErrorMsg = "Found MultiSurface element containing polygons with different srsNames")
   }
 
+  it should "succeed if a MultiSurface element doesn't have any surfaceMember elements in it" in {
+    testRuleSuccess(
+      rule = polygonsInSameMultiSurfaceHaveSameSrsName,
+      inputBag = "ddm-empty-multisurface")
+  }
+
+  it should "succeed if a MultiSurface element has surfaceMembers but no srsNames on any of them" in {
+    testRuleSuccess(
+      rule = polygonsInSameMultiSurfaceHaveSameSrsName,
+      inputBag = "ddm-no-srs-names")
+  }
+
   "pointsHaveAtLeastTwoValues" should "fail if a Point with one coordinate is found" in {
     testRuleViolation(
       rule = pointsHaveAtLeastTwoValues,


### PR DESCRIPTION
Fixes EASY-1882

#### When applied it will
* no longer return an error when a `MultiSurface` doesn't have any polygons

@DANS-KNAW/easy for review