### PR TITLE
EASY-1961 easy-validate-dans-bag moet message-from-depositor accepteren in v0

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -58,7 +58,7 @@ object ProfileVersion0 {
     NumberedRule("2.2(a)", containsFile(Paths.get("metadata/dataset.xml")), dependsOn = List("2.1")),
     NumberedRule("2.2(b)", containsFile(Paths.get("metadata/files.xml")), dependsOn = List("2.1")),
     // 2.3 does not state restrictions, so it does not need checking
-    NumberedRule("2.5", containsNothingElseThan(Paths.get("metadata"), Seq("dataset.xml", "files.xml", "agreements.xml")), dependsOn = List("2.1")),
+    NumberedRule("2.5", containsNothingElseThan(Paths.get("metadata"), Seq("dataset.xml", "files.xml", "agreements.xml", "message-from-depositor.txt")), dependsOn = List("2.1")),
 
     // METADATA
 
@@ -86,7 +86,7 @@ object ProfileVersion0 {
     NumberedRule("3.3.1", xmlFileIfExistsConformsToSchema(Paths.get("metadata/agreements.xml"), "Agreements metadata schema", xmlValidators("agreements.xml"))),
 
     // message-from-depositor.txt
-    NumberedRule("3.4.1", optionalFileIsUtf8Decodable(Paths.get("metadata/message-from-depositor"))),
+    NumberedRule("3.4.1", optionalFileIsUtf8Decodable(Paths.get("metadata/message-from-depositor.txt"))),
 
 
     // BAG-SEQUENCE


### PR DESCRIPTION
Fixes EASY-1961

#### When applied 
* you can add a message from the depositor (`message-from-depositor.txt`) in the `metadata` folder

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
ingest a test bag (with-depositor-message) that is attached to the JIRA issue (https://drivenbydata.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=EASY&modal=detail&selectedIssue=EASY-1961)

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
