### PR TITLE
EASY-2056: use new servlet-logging features from dans-scala-lib v1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServlet.scala
@@ -28,12 +28,12 @@ import scala.util.{ Failure, Try }
 class EasyValidateDansBagServlet(app: EasyValidateDansBagApp) extends ScalatraServlet
   with ServletLogger
   with PlainLogFormatter
+  with LogResponseBodyOnError
   with DebugEnhancedLogging {
 
   get("/") {
     contentType = "text/plain"
     Ok(s"EASY Validate DANS Bag Service running v${ app.version }.")
-      .logResponse
   }
 
   post("/validate") {
@@ -55,7 +55,7 @@ class EasyValidateDansBagServlet(app: EasyValidateDansBagApp) extends ScalatraSe
       case t =>
         logger.error(s"Server error: ${ t.getMessage }", t)
         InternalServerError(s"[${ new DateTime() }] The server encountered an error. Consult the logs.")
-    }.logResponse
+    }
   }
 
   private def getFileUrl(uriStr: String): Try[URI] = Try {


### PR DESCRIPTION
Fixes EASY-2056

#### When applied it will
* no longer use `.logResponse` to log the servlet response
* add `LogResponseBodyOnError` trait to servlet definition

@DANS-KNAW/easy for review