### PR TITLE
EASY-2021 Corrigeer aanroepen van bag-store op nieuwe percent-encoding regels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServletSpec.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.validatebag
 import java.net.URI
 
 import better.files.File
-import com.google.common.net.UrlEscapers
+import nl.knaw.dans.lib.encode.StringEncoding
 import nl.knaw.dans.easy.validatebag.InfoPackageType.SIP
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.eclipse.jetty.http.HttpStatus.{ BAD_REQUEST_400, OK_200 }
@@ -35,7 +35,7 @@ class EasyValidateDansBagServletSpec extends TestSupportFixture
   addServlet(validateBagServlet, "/*")
 
   def encodedURI(file: File): String = {
-    UrlEscapers.urlPathSegmentEscaper().escape(file.uri.toString)
+    file.uri.toString.escapeString
   }
 
   "the validate handler" should "return a 200 and the response when presented a valid bag uri" in {


### PR DESCRIPTION
#### When applied it
* replaces calls to `Guava UrlEscapers` methods with calls to `dans-scala-lib `encoding methods
  (which in turn make use of `Guava PercentEscaper`)


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-auth-info                 | [DANS-KNAW/easy-auth-info/pull/23] | ..
easy-bag-store                | [DANS-KNAW/easy-bag-store/pull/91] | ..
easy-download                | [DANS-KNAW/easy-download/pull/33] | ..
easy-ingest-flow             | [DANS-KNAW/easy-ingest-flow/pull/109] | ..
easy-solr4files-index      | [DANS-KNAW/easy-solr4files-index/pull/39] | ..
