### PR TITLE
EASY-2114: DANS license causes http500 in easy-validate-dans-bag

### DIFF
--- a/src/main/assembly/dist/cfg/licenses.txt
+++ b/src/main/assembly/dist/cfg/licenses.txt
@@ -22,3 +22,4 @@ http://www.ohwr.org/attachments/2388/cern_ohl_v_1_2.txt
 http://www.ohwr.org/projects/cernohl/wiki
 http://www.tapr.org/ohl.html
 http://www.tapr.org/TAPR_Open_Hardware_License_v1.0.txt
+http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/TargetBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/TargetBag.scala
@@ -22,7 +22,7 @@ import gov.loc.repository.bagit.reader.BagReader
 import nl.knaw.dans.easy.validatebag.validation.fail
 
 import scala.util.Try
-import scala.xml.{ Elem, XML }
+import scala.xml.{ Node, Utility, XML }
 
 /**
  * Interface to the bag under validation.
@@ -46,14 +46,18 @@ class TargetBag(val bagDir: BagDir, profileVersion: ProfileVersion = 0) {
 
   lazy val tryBag: Try[Bag] = Try { bagReader.read(bagDir.path) }
 
-  lazy val tryDdm: Try[Elem] = Try {
-    XML.loadFile((bagDir / ddmPath.toString).toJava)
+  lazy val tryDdm: Try[Node] = Try {
+    Utility.trim {
+      XML.loadFile((bagDir / ddmPath.toString).toJava)
+    }
   }.recoverWith {
     case t: Throwable => Try { fail(s"Unparseable XML: ${ t.getMessage }") }
   }
 
-  lazy val tryFilesXml: Try[Elem] = Try {
-    XML.loadFile((bagDir / filesXmlPath.toString).toJava)
+  lazy val tryFilesXml: Try[Node] = Try {
+    Utility.trim {
+      XML.loadFile((bagDir / filesXmlPath.toString).toJava)
+    }
   }.recoverWith {
     case t: Throwable => Try { fail(s"Unparseable XML: ${ t.getMessage }") }
   }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -238,7 +238,7 @@ package object metadata extends DebugEnhancedLogging {
   }
 
   private def getMultiSurfaces(ddm: Node) = Try {
-    (ddm \\ "MultiSurface").filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Node]]
+    (ddm \\ "MultiSurface").filter(_.namespace == gmlNamespace)
   }
 
   private def validateMultiSurface(ms: Node): Try[Unit] = {
@@ -261,7 +261,7 @@ package object metadata extends DebugEnhancedLogging {
   }
 
   private def getGmlPoints(ddm: Node) = Try {
-    ((ddm \\ "Point") ++ (ddm \\ "lowerCorner") ++ (ddm \\ "upperCorner")).filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Node]]
+    ((ddm \\ "Point") ++ (ddm \\ "lowerCorner") ++ (ddm \\ "upperCorner")).filter(_.namespace == gmlNamespace)
   }
 
   private def validatePoint(point: Node) = {

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -105,7 +105,7 @@ package object metadata extends DebugEnhancedLogging {
     } yield ()
   }
 
-  private def getDoiIdentifiers(ddm: Elem): Try[Seq[String]] = Try {
+  private def getDoiIdentifiers(ddm: Node): Try[Seq[String]] = Try {
     val dois = (ddm \\ "identifier").filter(hasXsiType(identifierTypeNamespace, "DOI"))
     if (dois.isEmpty) fail("DOI identifier is missing")
     dois.map(_.text)
@@ -161,7 +161,7 @@ package object metadata extends DebugEnhancedLogging {
     } yield ()
   }
 
-  private def daisAreValid(ddm: Elem): Try[Unit] = Try {
+  private def daisAreValid(ddm: Node): Try[Unit] = Try {
     val dais = (ddm \\ "DAI").filter(_.namespace == dcxDaiNamespace)
     logger.debug(s"DAIs to check: ${ dais.mkString(", ") }")
     val invalidDais = dais.map(_.text.stripPrefix(daiPrefix)).filterNot(s => digest(s.slice(0, s.length - 1), 9) == s.last)
@@ -204,13 +204,13 @@ package object metadata extends DebugEnhancedLogging {
     } yield ()
   }
 
-  private def getPolygonPosLists(parent: Elem): Try[Seq[Node]] = Try {
+  private def getPolygonPosLists(parent: Node): Try[Seq[Node]] = Try {
     trace(())
     val polygons = getPolygons(parent)
     polygons.flatMap(_ \\ "posList")
   }
 
-  private def getPolygons(parent: Elem) = (parent \\ "Polygon").filter(_.namespace == gmlNamespace)
+  private def getPolygons(parent: Node) = (parent \\ "Polygon").filter(_.namespace == gmlNamespace)
 
   private def validatePosList(node: Node): Try[Unit] = Try {
     trace(node)
@@ -237,11 +237,11 @@ package object metadata extends DebugEnhancedLogging {
     }
   }
 
-  private def getMultiSurfaces(ddm: Elem) = Try {
-    (ddm \\ "MultiSurface").filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Elem]]
+  private def getMultiSurfaces(ddm: Node) = Try {
+    (ddm \\ "MultiSurface").filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Node]]
   }
 
-  private def validateMultiSurface(ms: Elem): Try[Unit] = {
+  private def validateMultiSurface(ms: Node): Try[Unit] = {
     val polygons = getPolygons(ms)
     if (polygons.isEmpty || polygons.flatMap(_.attribute("srsName").map(_.text)).distinct.size <= 1) Success(())
     else Try(fail("Found MultiSurface element containing polygons with different srsNames"))
@@ -260,11 +260,11 @@ package object metadata extends DebugEnhancedLogging {
     }
   }
 
-  private def getGmlPoints(ddm: Elem) = Try {
-    ((ddm \\ "Point") ++ (ddm \\ "lowerCorner") ++ (ddm \\ "upperCorner")).filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Elem]]
+  private def getGmlPoints(ddm: Node) = Try {
+    ((ddm \\ "Point") ++ (ddm \\ "lowerCorner") ++ (ddm \\ "upperCorner")).filter(_.namespace == gmlNamespace).asInstanceOf[Seq[Node]]
   }
 
-  private def validatePoint(point: Elem) = {
+  private def validatePoint(point: Node) = {
     val coordinates = point.text.trim.split("""\s+""")
     if (coordinates.length > 1) Success(())
     else Try(fail(s"Point with only one coordinate: ${ point.text.trim }"))

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -129,12 +129,12 @@ package object metadata extends DebugEnhancedLogging {
    * @return normalized URI
    */
   def normalizeLicenseUri(uri: URI): Try[URI] = Try {
-    def normalizeLicenseUriPath(p: String) = {
+    def normalizeLicenseUriPath(p: String): String = {
       val nTrailingSlashes = p.toCharArray.reverse.takeWhile(_ == '/').length
       p.substring(0, p.length - nTrailingSlashes)
     }
 
-    def normalizeLicenseUriScheme(s: String) = {
+    def normalizeLicenseUriScheme(s: String): String = {
       if (s == "http" || s == "https") "http"
       else throw new IllegalArgumentException(s"Only http or https license URIs allowed. URI scheme found: $s")
     }
@@ -210,12 +210,16 @@ package object metadata extends DebugEnhancedLogging {
     polygons.flatMap(_ \\ "posList")
   }
 
-  private def getPolygons(parent: Node) = (parent \\ "Polygon").filter(_.namespace == gmlNamespace)
+  private def getPolygons(parent: Node): NodeSeq = {
+    (parent \\ "Polygon").filter(_.namespace == gmlNamespace)
+  }
 
   private def validatePosList(node: Node): Try[Unit] = Try {
     trace(node)
 
-    def offendingPosListMsg(values: Seq[String]) = s"(Offending posList starts with: ${ values.take(10).mkString(", ") }...)"
+    def offendingPosListMsg(values: Seq[String]): String = {
+      s"(Offending posList starts with: ${ values.take(10).mkString(", ") }...)"
+    }
 
     val values = node.text.split("""\s+""").toList
     val numberOfValues = values.size
@@ -237,7 +241,7 @@ package object metadata extends DebugEnhancedLogging {
     }
   }
 
-  private def getMultiSurfaces(ddm: Node) = Try {
+  private def getMultiSurfaces(ddm: Node): Try[NodeSeq] = Try {
     (ddm \\ "MultiSurface").filter(_.namespace == gmlNamespace)
   }
 
@@ -260,11 +264,11 @@ package object metadata extends DebugEnhancedLogging {
     }
   }
 
-  private def getGmlPoints(ddm: Node) = Try {
+  private def getGmlPoints(ddm: Node): Try[NodeSeq] = Try {
     ((ddm \\ "Point") ++ (ddm \\ "lowerCorner") ++ (ddm \\ "upperCorner")).filter(_.namespace == gmlNamespace)
   }
 
-  private def validatePoint(point: Node) = {
+  private def validatePoint(point: Node): Try[Unit] = {
     val coordinates = point.text.trim.split("""\s+""")
     if (coordinates.length > 1) Success(())
     else Try(fail(s"Point with only one coordinate: ${ point.text.trim }"))

--- a/src/test/resources/bags/ddm-correct-license-uri-on-new-line/bag-info.txt
+++ b/src/test/resources/bags/ddm-correct-license-uri-on-new-line/bag-info.txt
@@ -1,0 +1,3 @@
+Payload-Oxum: 0.1
+Bagging-Date: 2018-05-24
+Bag-Size: 2.4 KB

--- a/src/test/resources/bags/ddm-correct-license-uri-on-new-line/bagit.txt
+++ b/src/test/resources/bags/ddm-correct-license-uri-on-new-line/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-correct-license-uri-on-new-line/manifest-md5.txt
+++ b/src/test/resources/bags/ddm-correct-license-uri-on-new-line/manifest-md5.txt
@@ -1,0 +1,1 @@
+d41d8cd98f00b204e9800998ecf8427e  data/leeg.txt

--- a/src/test/resources/bags/ddm-correct-license-uri-on-new-line/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-correct-license-uri-on-new-line/metadata/dataset.xml
@@ -1,0 +1,35 @@
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd">
+    <ddm:profile>
+        <dc:title xml:lang="en">Title of the dataset</dc:title>
+        <dc:description xml:lang="la">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dc:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:author>
+                <dcx-dai:titles>Prof.</dcx-dai:titles>
+                <dcx-dai:initials>D.N.</dcx-dai:initials>
+                <dcx-dai:insertions>van den</dcx-dai:insertions>
+                <dcx-dai:surname>Aarden</dcx-dai:surname>
+                <dcx-dai:DAI>123456789</dcx-dai:DAI>
+                <dcx-dai:role>Distributor</dcx-dai:role>
+                <dcx-dai:organization>
+                    <dcx-dai:name xml:lang="en">Utrecht University</dcx-dai:name>
+                </dcx-dai:organization>
+            </dcx-dai:author>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2012-12</ddm:created>
+        <ddm:available>2013-05</ddm:available>
+        <ddm:audience>D20000</ddm:audience>
+        <ddm:audience>D24000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dct:license xsi:type="dct:URI">
+            https://creativecommons.org/licenses/by-sa/4.0/
+        </dct:license>
+        <dct:rightsHolder>Mr. Rights</dct:rightsHolder>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-correct-license-uri-on-new-line/metadata/files.xml
+++ b/src/test/resources/bags/ddm-correct-license-uri-on-new-line/metadata/files.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<files xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:dcterms="http://purl.org/dc/terms/">
+    <file filepath="data/leeg.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+</files>
+

--- a/src/test/resources/bags/ddm-correct-license-uri-on-new-line/tagmanifest-md5.txt
+++ b/src/test/resources/bags/ddm-correct-license-uri-on-new-line/tagmanifest-md5.txt
@@ -1,0 +1,5 @@
+7ab113ba4cf76f0631ec2d533bc60d65  bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
+49c4fb4dad642f9adddfe9031114f530  manifest-md5.txt
+94ce0e1cdfcd7f0094c9739d1c388cb8  metadata/dataset.xml
+a003fcd89e806445ce040287222943bf  metadata/files.xml

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -77,6 +77,12 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       inputBag = "metadata-correct")
   }
 
+  it should "succeed if the license is on a separate line" in {
+    testRuleSuccess(
+      rule = ddmMayContainDctermsLicenseFromList(licenses),
+      inputBag = "ddm-correct-license-uri-on-new-line")
+  }
+
   it should "succeed even if license is specified with https rather than http" in {
     testRuleSuccess(
       rule = ddmMayContainDctermsLicenseFromList(licenses),


### PR DESCRIPTION
fixes EASY-2114

#### When applied it will
* correctly read XML (wrapped in `Utility.trim`)
* remove unnecessary `asInstanceOf` calls
* add return types to private methods
* add license 'DANS general conditions of use'

@DANS-KNAW/easy for review