### PR TITLE
EASY-2220: maak ddm.xsd versieloos in validate-dans-bag

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -6,9 +6,9 @@ daemon.http.port=20180
 #
 # Schemas used to validate the various XML formats found in the bag.
 #
-schemas.ddm=https://easy.dans.knaw.nl/schemas/md/2018/03/ddm.xsd
-schemas.files=https://easy.dans.knaw.nl/schemas/bag/metadata/files/2018/04/files.xsd
-schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2019/01/agreements.xsd
+schemas.ddm=https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
+schemas.files=https://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd
+schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/agreements.xsd
 
 #
 # Bag store service to validate baq-sequence-related rules against.

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,7 +1,7 @@
 daemon.http.port=20180
-schemas.ddm=https://easy.dans.knaw.nl/schemas/md/2018/03/ddm.xsd
-schemas.files=https://easy.dans.knaw.nl/schemas/bag/metadata/files/2018/04/files.xsd
-schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/12/agreements.xsd
+schemas.ddm=https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
+schemas.files=https://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd
+schemas.agreements=https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/agreements.xsd
 bagstore-service.base-url=http://deasy.dans.knaw.nl:20110/
 bagstore-service.connection-timeout-milliseconds=5000
 bagstore-service.read-timeout-milliseconds=5000


### PR DESCRIPTION
Fixes EASY-2220

#### When applied it will
* fetch for validation versionless schema files `ddm.xsd`, `files.xsd` and `agreements.xsd`


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
