### PR TITLE
upgrade easy-licenses to v1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <inceptionYear>2018</inceptionYear>
     <properties>
         <main-class>nl.knaw.dans.easy.validatebag.Command</main-class>
-        <easy-licenses.version>1.0.3</easy-licenses.version>
+        <easy-licenses.version>1.0.4</easy-licenses.version>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>


### PR DESCRIPTION
upgrade easy-licenses from `v1.0.3` to `v1.0.4`

@DANS-KNAW/easy for review