### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/sequence/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/sequence/package.scala
@@ -22,12 +22,11 @@ import java.util.UUID
 import nl.knaw.dans.easy.validatebag.validation.fail
 import nl.knaw.dans.easy.validatebag.{ BagStore, TargetBag }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 
-import scala.util.{ Success, Try }
+import scala.util.{ Failure, Success, Try }
 
 package object sequence extends DebugEnhancedLogging {
-  private val uuidHexLength = 32
-  private val uuidCanonicalNumberOfDashes = 4
 
   def bagInfoIsVersionOfIfExistsPointsToArchivedBag(bagStore: BagStore)(t: TargetBag): Try[Unit] = {
     trace(())
@@ -49,8 +48,10 @@ package object sequence extends DebugEnhancedLogging {
     failIfNotTrueWithMessage(uri.getScheme == "urn", "Is-Version-Of value must be a URN")
     failIfNotTrueWithMessage(uri.getSchemeSpecificPart.startsWith("uuid:"), "Is-Version-Of URN must be of subtype UUID")
     val Array(_, uuidStr) = uri.getSchemeSpecificPart.split(':')
-    failIfNotTrueWithMessage(uuidStr.length == uuidHexLength + uuidCanonicalNumberOfDashes, "UUID must be in canonical textual representation")
-    UUID.fromString(uuidStr)
+    uuidStr.toUUID.toTry match {
+      case Success(uuid) => uuid
+      case Failure(e) => fail(e.getMessage)
+    }
   }
 
   private def failIfNotTrueWithMessage(bool: Boolean, msg: String): Unit = {

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/sequence/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/sequence/package.scala
@@ -21,10 +21,11 @@ import java.util.UUID
 
 import nl.knaw.dans.easy.validatebag.validation.fail
 import nl.knaw.dans.easy.validatebag.{ BagStore, TargetBag }
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Success, Try }
 
 package object sequence extends DebugEnhancedLogging {
 
@@ -48,10 +49,7 @@ package object sequence extends DebugEnhancedLogging {
     failIfNotTrueWithMessage(uri.getScheme == "urn", "Is-Version-Of value must be a URN")
     failIfNotTrueWithMessage(uri.getSchemeSpecificPart.startsWith("uuid:"), "Is-Version-Of URN must be of subtype UUID")
     val Array(_, uuidStr) = uri.getSchemeSpecificPart.split(':')
-    uuidStr.toUUID.toTry match {
-      case Success(uuid) => uuid
-      case Failure(e) => fail(e.getMessage)
-    }
+    uuidStr.toUUID.toTry.getOrRecover(e => fail(e.getMessage))
   }
 
   private def failIfNotTrueWithMessage(bool: Boolean, msg: String): Unit = {

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/sequence/SequenceRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/sequence/SequenceRulesSpec.scala
@@ -70,6 +70,6 @@ class SequenceRulesSpec extends TestSupportFixture with MockFactory {
 
   it should "fail if the UUID is NOT in canonical textual representation" in {
     expectUuidDoesNotExist()
-    testRuleViolation(rule = bagInfoIsVersionOfIfExistsPointsToArchivedBag(bagStoreMock), inputBag = "baginfo-with-is-version-of-invalid-uuid", includedInErrorMsg = "UUID must be in canonical textual representation", doubleCheckBagItValidity = false)
+    testRuleViolation(rule = bagInfoIsVersionOfIfExistsPointsToArchivedBag(bagStoreMock), inputBag = "baginfo-with-is-version-of-invalid-uuid", includedInErrorMsg = "String '75fc6989/hierook-4c7a-b49d-superinvalidenzo' is not a UUID", doubleCheckBagItValidity = false)
   }
 }


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
