### PR TITLE
EASY-2605: "Alternative identifier" veld wordt niet gevalideerd

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -363,11 +363,11 @@ package object metadata extends DebugEnhancedLogging {
   }
 
   private def getDoiTypeElementValues(ddm: Node): Try[(UrlValidationKey, Seq[String])] = Try {
-    DoiKey -> getElementValues(ddm, "scheme", List("DOI"))
+    DoiKey -> getElementValues(ddm, "scheme", List("DOI", "id-type:DOI"))
   }
 
   private def getUrnTypeElementValues(ddm: Node): Try[(UrlValidationKey, Seq[String])] = Try {
-    UrnKey -> getElementValues(ddm, "scheme", List("URN"))
+    UrnKey -> getElementValues(ddm, "scheme", List("URN", "id-type:URN"))
   }
 
   private def getElementValues(node: Node, attribute: String, attributeValues: List[String]): Seq[String] = {

--- a/src/test/resources/bags/ddm-incorrect-urls/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-incorrect-urls/metadata/dataset.xml
@@ -21,6 +21,8 @@
         <ddm:references scheme="URL">xttp://abc.def</ddm:references>
         <ddm:references scheme="DOI">99.1234.abc</ddm:references>
         <ddm:references scheme="URN">uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66</ddm:references>
+        <ddm:isFormatOf scheme="id-type:DOI">joopajoo</ddm:isFormatOf>
+        <ddm:isFormatOf scheme="id-type:URN">niinpä</ddm:isFormatOf>
         <ddm:subject schemeURI="xttps://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="xttps://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
         <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
         <dc:subject>metaal</dc:subject>

--- a/src/test/resources/bags/ddm-incorrect-urls/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-incorrect-urls/tagmanifest-sha1.txt
@@ -1,5 +1,5 @@
 fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
-4defa022edf1c9893806d042e48ef627dddd72bb  metadata/dataset.xml
+61db7e19432e9e5d6c2f75a8697ac215ba798d4d  metadata/dataset.xml
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
 37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
 a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -174,12 +174,14 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       inputBag = "ddm-incorrect-urls",
       includedInErrorMsg =
         """(0) DOI '99.1234.abc' is not valid
-          |(1) URN 'uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66' is not valid
-          |(2) protocol 'xttps' in URI 'xttps://www.portable-antiquities.nl/pan/#/object/public/8136' is not one of the accepted protocols [http,https] (value of attribute 'href')
-          |(3) protocol 'xttps' in URI 'xttps://data.cultureelerfgoed.nl/term/id/pan/PAN' is not one of the accepted protocols [http,https] (value of attribute 'schemeURI')
-          |(4) protocol 'xttps' in URI 'xttps://data.cultureelerfgoed.nl/term/id/pan/17-01-01' is not one of the accepted protocols [http,https] (value of attribute 'valueURI')
-          |(5) protocol 'ettp' in URI 'ettp://creativecommons.org/licenses/by-nc-sa/4.0/' is not one of the accepted protocols [http,https]
-          |(6) protocol 'xttp' in URI 'xttp://abc.def' is not one of the accepted protocols [http,https]
+          |(1) DOI 'joopajoo' is not valid
+          |(2) URN 'uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66' is not valid
+          |(3) URN 'niinpä' is not valid
+          |(4) protocol 'xttps' in URI 'xttps://www.portable-antiquities.nl/pan/#/object/public/8136' is not one of the accepted protocols [http,https] (value of attribute 'href')
+          |(5) protocol 'xttps' in URI 'xttps://data.cultureelerfgoed.nl/term/id/pan/PAN' is not one of the accepted protocols [http,https] (value of attribute 'schemeURI')
+          |(6) protocol 'xttps' in URI 'xttps://data.cultureelerfgoed.nl/term/id/pan/17-01-01' is not one of the accepted protocols [http,https] (value of attribute 'valueURI')
+          |(7) protocol 'ettp' in URI 'ettp://creativecommons.org/licenses/by-nc-sa/4.0/' is not one of the accepted protocols [http,https]
+          |(8) protocol 'xttp' in URI 'xttp://abc.def' is not one of the accepted protocols [http,https]
           |""".stripMargin)
   }
 


### PR DESCRIPTION
Fixes EASY-2605

#### When applied it will
* validate also `DOIs` and `URNs` in `alternative identifier` (`scheme="id-type:DOI"` and `scheme="id-type:URNI"`)


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
