### PR TITLE
NO-JIRA: exclude DOI XML bodies when a href body is provided

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -363,19 +363,32 @@ package object metadata extends DebugEnhancedLogging {
   }
 
   private def getDoiTypeElementValues(ddm: Node): Try[(UrlValidationKey, Seq[String])] = Try {
-    DoiKey -> getElementValues(ddm, "scheme", List("DOI", "id-type:DOI"))
+    DoiKey -> getElementValues(ddm, "scheme", List("DOI", "id-type:DOI"), List("href"))
   }
 
   private def getUrnTypeElementValues(ddm: Node): Try[(UrlValidationKey, Seq[String])] = Try {
-    UrnKey -> getElementValues(ddm, "scheme", List("URN", "id-type:URN"))
+    UrnKey -> getElementValues(ddm, "scheme", List("URN", "id-type:URN"), List("href"))
   }
 
-  private def getElementValues(node: Node, attribute: String, attributeValues: List[String]): Seq[String] = {
+  /**
+   * Returns the bodies of all leaf nodes in ''node'', for which the given ''attribute'' has one of the given ''attributeValues'',
+   * except if that leaf node also contains an attribute in ''excludeOnAttribute''.
+   *
+   * @param node the `Node` for which to find all bodies in its leafs
+   * @param attribute only include bodies of leaf nodes containing this attribute
+   * @param attributeValues only include bodies of leaf nodes when an attribute contains one of these values
+   * @param excludeOnAttribute only include bodies of leaf nodes that do NOT contain one of these attributes
+   * @return a list of bodies of leaf nodes, filtered by the given attribute filters.
+   */
+  private def getElementValues(node: Node, attribute: String, attributeValues: List[String], excludeOnAttribute: List[String] = Nil): Seq[String] = {
     (node \\ "_")
       .withFilter(_.attributes
         .filter(_.prefixedKey == attribute)
         .filter(attributeValues contains _.value.text)
         .nonEmpty)
+      .withFilter(_.attributes
+        .filter(md => excludeOnAttribute.contains(md.prefixedKey))
+        .isEmpty)
       .map(_.text)
   }
 

--- a/src/test/resources/bags/ddm-correct-urls/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-correct-urls/metadata/dataset.xml
@@ -21,8 +21,15 @@
         <ddm:references scheme="URL">http://abc.def</ddm:references>
         <ddm:references scheme="DOI">10.17026/test-123-456</ddm:references>
         <ddm:references scheme="DOI">https://dx.doi.org/doi:10.17026/test-123-456</ddm:references>
+        <ddm:references scheme="DOI" href="https://dx.doi.org/doi:10.17026/test-123-456">a doi referencing my dataset</ddm:references>
         <ddm:references scheme="DOI">http://doi.org/10.17026/test-123-456</ddm:references>
         <ddm:references scheme="URN">urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66()+,-\.:=@;$_!*'%/?#</ddm:references>
+        <ddm:references scheme="id-type:URL">http://abc.def</ddm:references>
+        <ddm:references scheme="id-type:DOI">10.17026/test-123-456</ddm:references>
+        <ddm:references scheme="id-type:DOI">https://dx.doi.org/doi:10.17026/test-123-456</ddm:references>
+        <ddm:references scheme="id-type:DOI" href="https://dx.doi.org/doi:10.17026/test-123-456">a doi referencing my dataset</ddm:references>
+        <ddm:references scheme="id-type:DOI">http://doi.org/10.17026/test-123-456</ddm:references>
+        <ddm:references scheme="id-type:URN">urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66()+,-\.:=@;$_!*'%/?#</ddm:references>
         <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN" subjectScheme="PAN thesaurus ideaaltypes" valueURI="https://data.cultureelerfgoed.nl/term/id/pan/17-01-01" xml:lang="en">knobbed sickle</ddm:subject>
         <ddm:subject schemeURI="http://vocab.getty.edu/aat/" subjectScheme="Art and Architecture Thesaurus" valueURI="http://vocab.getty.edu/aat/300264860" xml:lang="en">Unknown</ddm:subject>
         <dc:subject>metaal</dc:subject>

--- a/src/test/resources/bags/ddm-correct-urls/tagmanifest-sha1.txt
+++ b/src/test/resources/bags/ddm-correct-urls/tagmanifest-sha1.txt
@@ -1,5 +1,5 @@
 fe98dfbf68b75c53588f2097bd2f36c4751afe78  bag-info.txt
-a8f583fbe92dc1e52c8b76a0e56718e44966a6e7  metadata/dataset.xml
+7f0661f689423848b6b268dd5d5bb636a9e1cbc1  metadata/dataset.xml
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
 37f14d418a51001c0a42d0a0cafd4e09c398e1d2  manifest-sha1.txt
 a9e97be057cf2a1636ef0c8ba97098830a2973a2  metadata/files.xml


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* exclude DOI XML bodies when a href body is provided

@DANS-KNAW/easy for review

#### Example
```xml
<ddm:references scheme="id-type:DOI">https://dx.doi.org/doi:10.17026/test-123-456</ddm:references>
<ddm:references scheme="id-type:DOI" href="https://dx.doi.org/doi:10.17026/test-123-456">a doi referencing my dataset</ddm:references>
```

For the first example, the body should be validated to be a correct DOI (URL).
For the second example, the body should NOT be validated, since an `href` is already present.