### PR TITLE
EASY-2615: doi validation

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/package.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy
 
 import better.files._
+import nl.knaw.dans.easy.validatebag.rules.{ ProfileVersion0, ProfileVersion1 }
 
 import scala.util.{ Failure, Try }
 
@@ -28,8 +29,8 @@ package object validatebag {
   type RuleBase = Seq[NumberedRule]
 
   val profileVersionDois = Map(
-    0 -> "doi:10.17026/dans-z52-ybfe",
-    1 -> "doi:10.17026/dans-zf3-q54n"
+    0 -> ProfileVersion0.versionUri,
+    1 -> ProfileVersion1.versionUri,
   )
 
   object InfoPackageType extends Enumeration {

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -78,7 +78,8 @@ object ProfileVersion0 {
     // dataset.xml
     NumberedRule("3.1.1", xmlFileConformsToSchema(Paths.get("metadata/dataset.xml"), "DANS dataset metadata schema", xmlValidators("dataset.xml")), dependsOn = List("2.2(a)")),
     NumberedRule("3.1.2", ddmMayContainDctermsLicenseFromList(allowedLicences), dependsOn = List("3.1.1")),
-    NumberedRule("3.1.3", ddmContainsValidDoiIdentifier, AIP, dependsOn = List("3.1.1")),
+    NumberedRule("3.1.3(a)", ddmContainsDoiIdentifier, AIP, dependsOn = List("3.1.1")),
+    NumberedRule("3.1.3(b)", ddmDoiIdentifiersAreValid, dependsOn = List("3.1.1")),
     NumberedRule("3.1.4", ddmDaisAreValid, dependsOn = List("3.1.1")),
     NumberedRule("3.1.5", ddmGmlPolygonPosListIsWellFormed, dependsOn = List("3.1.1")),
     NumberedRule("3.1.6", polygonsInSameMultiSurfaceHaveSameSrsName, dependsOn = List("3.1.1")),

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -65,7 +65,7 @@ package object metadata extends DebugEnhancedLogging {
     (t.bagDir / xmlFile.toString).inputStream.map(validator.validate).map {
       _.recoverWith { case t: Throwable => Try(fail(s"$xmlFile does not conform to $schemaName: ${ t.getMessage }")) }
     }
-    }.get()
+  }.get()
 
   def filesXmlConformsToSchemaIfFilesNamespaceDeclared(validator: XmlValidator)
                                                       (t: TargetBag): Try[Unit] = {
@@ -111,7 +111,16 @@ package object metadata extends DebugEnhancedLogging {
     new URI(s)
   }
 
-  def ddmContainsValidDoiIdentifier(t: TargetBag): Try[Unit] = {
+  def ddmContainsDoiIdentifier(t: TargetBag): Try[Unit] = {
+    trace(())
+    for {
+      ddm <- t.tryDdm
+      dois <- getDoiIdentifiers(ddm)
+      _ = if (dois.isEmpty) fail("DOI identifier is missing")
+    } yield ()
+  }
+
+  def ddmDoiIdentifiersAreValid(t: TargetBag): Try[Unit] = {
     trace(())
     for {
       ddm <- t.tryDdm
@@ -122,7 +131,6 @@ package object metadata extends DebugEnhancedLogging {
 
   private def getDoiIdentifiers(ddm: Node): Try[Seq[String]] = Try {
     val dois = (ddm \\ "identifier").filter(hasXsiType(identifierTypeNamespace, "DOI"))
-    if (dois.isEmpty) fail("DOI identifier is missing")
     dois.map(_.text)
   }
 
@@ -376,9 +384,9 @@ package object metadata extends DebugEnhancedLogging {
    * Returns the bodies of all leaf nodes in ''node'', for which the given ''attribute'' has one of the given ''attributeValues'',
    * except if that leaf node also contains an attribute in ''excludeOnAttribute''.
    *
-   * @param node the `Node` for which to find all bodies in its leafs
-   * @param attribute only include bodies of leaf nodes containing this attribute
-   * @param attributeValues only include bodies of leaf nodes when an attribute contains one of these values
+   * @param node               the `Node` for which to find all bodies in its leafs
+   * @param attribute          only include bodies of leaf nodes containing this attribute
+   * @param attributeValues    only include bodies of leaf nodes when an attribute contains one of these values
    * @param excludeOnAttribute only include bodies of leaf nodes that do NOT contain one of these attributes
    * @return a list of bodies of leaf nodes, filtered by the given attribute filters.
    */

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -112,6 +112,7 @@ package object metadata extends DebugEnhancedLogging {
   }
 
   def ddmContainsValidDoiIdentifier(t: TargetBag): Try[Unit] = {
+    trace(())
     for {
       ddm <- t.tryDdm
       dois <- getDoiIdentifiers(ddm)
@@ -177,6 +178,7 @@ package object metadata extends DebugEnhancedLogging {
   }
 
   def ddmDaisAreValid(t: TargetBag): Try[Unit] = {
+    trace(())
     for {
       ddm <- t.tryDdm
       _ <- daisAreValid(ddm)

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -164,7 +164,9 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
   }
 
   "new test approach" should "succeed" in pendingUntilFixed { // seems to be ok in servletSpec
-    // TODO rewrite tests to copy the valid-bag into testDir with a variant of the ddm
+    // TODO Rewrite tests to copy the valid-bag into testDir with a variant of the ddm.
+    //  Returning a tuple with the three types of tests (rule, AIP, SIP) might make the new test approach less verbose
+    //  while still being flexible in predicting the expected results.
     validateRules(new TargetBag(bagsDir / "valid-bag", 0), AIP, allRules) shouldBe Success(())
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -148,7 +148,7 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
 
   private val allRules: Seq[NumberedRule] = {
     val xmlValidator = new XmlValidator(null) {override def validate(is: InputStream): Try[Unit] = Success(()) }
-    val validatorMap = { Map("dataset.xml" -> xmlValidator, "files.xml" -> xmlValidator, "agreements.xml" -> xmlValidator) }
+    val validatorMap = Map("dataset.xml" -> xmlValidator, "files.xml" -> xmlValidator, "agreements.xml" -> xmlValidator)
     ProfileVersion0.apply(validatorMap, allowedLicences = Seq.empty, BagStore(new URI(""), 1000, 1000))
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -20,7 +20,7 @@ import java.net.{ URI, URL }
 import java.nio.file.Paths
 
 import javax.xml.validation.SchemaFactory
-import nl.knaw.dans.easy.validatebag.InfoPackageType.InfoPackageType
+import nl.knaw.dans.easy.validatebag.InfoPackageType.{ AIP, InfoPackageType, SIP }
 import nl.knaw.dans.easy.validatebag._
 import nl.knaw.dans.easy.validatebag.rules.ProfileVersion0
 import nl.knaw.dans.easy.validatebag.validation.{ RuleViolationDetailsException, RuleViolationException }
@@ -146,40 +146,50 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       inputBag = "ddm-correct-dai")
   }
 
-  "ddmContainsValidDoiIdentifier" should "succeed if one or more DOIs are present and they are valid" in {
-    testRuleSuccess(
-      rule = ddmContainsValidDoiIdentifier,
-      inputBag = "ddm-correct-doi")
-  }
-
-  it should "fail if there is no DOI-identifier" in {
-    testRuleViolation(
-      rule = ddmContainsValidDoiIdentifier,
-      inputBag = "ddm-missing-doi",
-      includedInErrorMsg = "DOI identifier is missing")
-  }
-
-  it should "report invalid DOI-identifiers" in {
-    val msg = "Invalid DOIs: 11.1234/fantasy-doi-id, 10/1234/fantasy-doi-id, 10.1234.fantasy-doi-id, http://doi.org/10.1234.567/issn-987-654, https://doi.org/10.1234.567/issn-987-654"
-    val bag = new TargetBag(bagsDir / "ddm-incorrect-doi", 0)
-    ddmContainsValidDoiIdentifier(bag) shouldBe Failure(RuleViolationDetailsException(msg))
-    validateAllRules(bag, InfoPackageType.AIP) shouldBe aRuleViolation("3.1.3", msg)
-    validateAllRules(bag, InfoPackageType.SIP) shouldBe Success(())
-  }
-
   private val allRules: Seq[NumberedRule] = {
     val xmlValidator = new XmlValidator(null) {override def validate(is: InputStream): Try[Unit] = Success(()) }
     val validatorMap = { Map("dataset.xml" -> xmlValidator, "files.xml" -> xmlValidator, "agreements.xml" -> xmlValidator) }
     ProfileVersion0.apply(validatorMap, allowedLicences = Seq.empty, BagStore(new URI(""), 1000, 1000))
-      .filterNot(rule => Seq("3.1.2", "1.2.6(a)").contains(rule.nr))
   }
 
   private def aRuleViolation(ruleNumber: RuleNumber, msg: String) = {
     Failure(CompositeException(Seq(RuleViolationException(ruleNumber, msg))))
   }
 
-  private def validateAllRules(bag: TargetBag, infoPackageType: InfoPackageType) = {
-    validation.checkRules(bag, allRules, infoPackageType)(isReadable = _.isReadable)
+  private def validateRules(bag: TargetBag,
+                            infoPackageType: InfoPackageType,
+                            rules: Seq[NumberedRule] = allRules.filterNot(rule => Seq("3.1.2", "1.2.6(a)", "1.2.6(b)").contains(rule.nr))
+                           ): Try[Unit] = {
+    validation.checkRules(bag, rules, infoPackageType)(isReadable = _.isReadable)
+  }
+
+  "new test approach" should "succeed" in pendingUntilFixed { // seems to be ok in servletSpec
+    // TODO rewrite tests to copy the valid-bag into testDir with a variant of the ddm
+    validateRules(new TargetBag(bagsDir / "valid-bag", 0), AIP, allRules) shouldBe Success(())
+  }
+
+  "ddmContainsDoiIdentifier" should "succeed if one or more DOIs are present" in {
+    val bag = new TargetBag(bagsDir / "ddm-correct-doi", 0)
+    ddmContainsDoiIdentifier(bag) shouldBe Success(())
+    validateRules(bag, AIP) shouldBe Success(())
+    validateRules(bag, SIP) shouldBe Success(())
+  }
+
+  it should "fail if there is no DOI-identifier" in {
+    val msg = "DOI identifier is missing"
+    val bag = new TargetBag(bagsDir / "ddm-missing-doi", 0)
+    ddmContainsDoiIdentifier(bag) shouldBe Failure(RuleViolationDetailsException(msg))
+    validateRules(bag, SIP) shouldBe Success(())
+    validateRules(bag, AIP) shouldBe aRuleViolation("3.1.3(a)", msg)
+  }
+
+  "ddmDoiIdentifiersAreValid" should "report invalid DOI-identifiers" in {
+    val msg = "Invalid DOIs: 11.1234/fantasy-doi-id, 10/1234/fantasy-doi-id, 10.1234.fantasy-doi-id, http://doi.org/10.1234.567/issn-987-654, https://doi.org/10.1234.567/issn-987-654"
+    val bag = new TargetBag(bagsDir / "ddm-incorrect-doi", 0)
+    ddmContainsDoiIdentifier(bag) shouldBe Success(())
+    ddmDoiIdentifiersAreValid(bag) shouldBe Failure(RuleViolationDetailsException(msg))
+    validateRules(bag, AIP) shouldBe aRuleViolation("3.1.3(b)", msg)
+    validateRules(bag, SIP) shouldBe aRuleViolation("3.1.3(b)", msg)
   }
 
   "allUrlsAreValid" should "succeed with valid urls" in {


### PR DESCRIPTION
Fixes EASY-2615 doi validation

#### When applied it will
* have the DOI rule split in two: presence and syntax
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] See issue 
![image](https://user-images.githubusercontent.com/10553630/77140649-88afd300-6a7a-11ea-8ff3-d98d1fed53c7.png)


#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
