### PR TITLE
EASY-2689: Make SHA-1 mandatory only for AIPs

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -49,8 +49,8 @@ object ProfileVersion0 {
     NumberedRule("1.2.6(b)", bagInfoDoesNotContain("EASY-User-Account"), SIP, dependsOn = List("1.2.1")),
 
     // Manifests
-    NumberedRule("1.3.1(a)", containsFile(Paths.get("manifest-sha1.txt"))),
-    NumberedRule("1.3.1(b)", bagShaPayloadManifestContainsAllPayloadFiles, dependsOn = List("1.2.1", "1.3.1(a)")),
+    NumberedRule("1.3.1(a)", containsFile(Paths.get("manifest-sha1.txt")), AIP),
+    NumberedRule("1.3.1(b)", bagShaPayloadManifestContainsAllPayloadFiles, AIP, dependsOn = List("1.2.1", "1.3.1(a)")),
     // 1.3.2 does not state restrictions, so it does not need checking
 
     // STRUCTURAL

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion1.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion1.scala
@@ -46,8 +46,8 @@ object ProfileVersion1 {
     // 1.2.6(b) does not state restrictions, so it does not need checking
 
     // Manifests
-    NumberedRule("1.3.1(a)", containsFile(Paths.get("manifest-sha1.txt"))),
-    NumberedRule("1.3.1(b)", bagShaPayloadManifestContainsAllPayloadFiles, dependsOn = List("1.3.1(a)")),
+    NumberedRule("1.3.1(a)", containsFile(Paths.get("manifest-sha1.txt")), AIP),
+    NumberedRule("1.3.1(b)", bagShaPayloadManifestContainsAllPayloadFiles, AIP, dependsOn = List("1.3.1(a)")),
     // 1.3.2 does not state restrictions, so it does not need checking
 
 

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServletSpec.scala
@@ -19,7 +19,7 @@ import java.net.URI
 
 import better.files.File
 import nl.knaw.dans.lib.encode.StringEncoding
-import nl.knaw.dans.easy.validatebag.InfoPackageType.SIP
+import nl.knaw.dans.easy.validatebag.InfoPackageType.{SIP, AIP}
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.eclipse.jetty.http.HttpStatus.{ BAD_REQUEST_400, OK_200 }
 import org.scalatest.OptionValues._
@@ -48,7 +48,7 @@ class EasyValidateDansBagServletSpec extends TestSupportFixture
     }
   }
 
-  it should "return a 200 and a response including 'compliant: false' and reasons when presented an invalid bag" in {
+  it should "return a 200 and a response including 'compliant: false' and reasons when presented an invalid SIP bag" in {
     post(uri = createValidateURL("SIP", "metadata-correct"), headers = Seq(("Accept", "application/json"))) {
       status shouldBe OK_200
       val resultMessage = ResultMessage.read(body)
@@ -57,9 +57,26 @@ class EasyValidateDansBagServletSpec extends TestSupportFixture
       resultMessage.profileVersion shouldBe 0
       resultMessage.infoPackageType shouldBe SIP
       resultMessage.isCompliant shouldBe false
-      resultMessage.ruleViolations.value.toList should contain inOrderOnly(
+      resultMessage.ruleViolations.value.toList should contain (
         ("1.2.4(a)", "bag-info.txt must contain exactly one 'Created' element; number found: 0"),
+      )
+    }
+  }
+
+  it should "return a 200 and a response including 'compliant: false' and reasons when presented an invalid AIP bag" in {
+    post(uri = createValidateURL("AIP", "metadata-correct"), headers = Seq(("Accept", "application/json"))) {
+      status shouldBe OK_200
+      val resultMessage = ResultMessage.read(body)
+      resultMessage.bagUri shouldBe new URI(s"file://${ bagsDir.path.toAbsolutePath }/metadata-correct/")
+      resultMessage.bag shouldBe "metadata-correct"
+      resultMessage.profileVersion shouldBe 0
+      resultMessage.infoPackageType shouldBe AIP
+      resultMessage.isCompliant shouldBe false
+      resultMessage.ruleViolations.value.toList should contain inOrderOnly (
+        ("1.2.4(a)", "bag-info.txt must contain exactly one 'Created' element; number found: 0"),
+        ("1.2.6(a)", "bag-info.txt must contain exactly one 'EASY-User-Account' element; number found: 0"),
         ("1.3.1(a)", "Mandatory file 'manifest-sha1.txt' not found in bag."),
+        ("3.1.3(a)", "DOI identifier is missing"),
       )
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServletSpec.scala
@@ -57,8 +57,8 @@ class EasyValidateDansBagServletSpec extends TestSupportFixture
       resultMessage.profileVersion shouldBe 0
       resultMessage.infoPackageType shouldBe SIP
       resultMessage.isCompliant shouldBe false
-      resultMessage.ruleViolations.value.toList should contain (
-        ("1.2.4(a)", "bag-info.txt must contain exactly one 'Created' element; number found: 0"),
+      resultMessage.ruleViolations.value.toList should contain only (
+        ("1.2.4(a)", "bag-info.txt must contain exactly one 'Created' element; number found: 0")
       )
     }
   }


### PR DESCRIPTION
Fixes EASY-2689

#### When applied it will
* Only check for SHA-1 payload manifests in AIPs, not in SIPs

#### Where should the reviewer @DANS-KNAW/easy start?

#### Related PR
* [x] https://github.com/DANS-KNAW/dans-bagit-profile/pull/11
* [x] awaiting PR on `easy-ingest-flow` to be completed (EASY-2690, https://github.com/DANS-KNAW/easy-ingest-flow/pull/141)