### PR TITLE
EASY-2729: Make Rightsholder optional for CC0 licensed deposits

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.{ CharacterCodingException, Charset }
 import java.nio.file.{ Path, Paths }
 
-import nl.knaw.dans.easy.validatebag.validation.{ fail, _ }
+import nl.knaw.dans.easy.validatebag.validation._
 import nl.knaw.dans.easy.validatebag.{ TargetBag, XmlValidator }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.{ CharacterCodingException, Charset }
 import java.nio.file.{ Path, Paths }
 
-import nl.knaw.dans.easy.validatebag.validation._
+import nl.knaw.dans.easy.validatebag.validation.{ fail, _ }
 import nl.knaw.dans.easy.validatebag.{ TargetBag, XmlValidator }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -98,8 +98,8 @@ package object metadata extends DebugEnhancedLogging {
               _ = if (licenseUri.getScheme != "http" && licenseUri.getScheme != "https") fail("License URI must have scheme http or https")
               normalizedLicenseUri <- normalizeLicenseUri(licenseUri)
               _ = if (!allowedLicenses.contains(normalizedLicenseUri)) fail(s"Found unknown or unsupported license: $licenseUri")
+              _ = if (rightsHolders.isEmpty && ! normalizedLicenseUri.toString.equals("http://creativecommons.org/publicdomain/zero/1.0")) fail(s"Valid license found, but no rightsHolder specified")
             } yield ()).get
-            if (rightsHolders.isEmpty) fail("Valid license found, but no rightsHolder specified")
           case Nil | _ :: Nil =>
             debug("No licences with xsi:type=\"dcterms:URI\"")
           case _ => fail(s"Found ${ licenses.size } dcterms:license elements. Only one license is allowed.")

--- a/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/bag-info.txt
+++ b/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/bag-info.txt
@@ -1,0 +1,3 @@
+Payload-Oxum: 0.1
+Bagging-Date: 2020-05-28
+Bag-Size: 2.3 KB

--- a/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/bagit.txt
+++ b/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/manifest-md5.txt
+++ b/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/manifest-md5.txt
@@ -1,0 +1,1 @@
+d41d8cd98f00b204e9800998ecf8427e  data/leeg.txt

--- a/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/metadata/dataset.xml
+++ b/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/metadata/dataset.xml
@@ -1,0 +1,32 @@
+<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd">
+    <ddm:profile>
+        <dc:title xml:lang="en">Title of the dataset</dc:title>
+        <dc:description xml:lang="la">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dc:description>
+        <dcx-dai:creatorDetails>
+            <dcx-dai:author>
+                <dcx-dai:titles>Prof.</dcx-dai:titles>
+                <dcx-dai:initials>D.N.</dcx-dai:initials>
+                <dcx-dai:insertions>van den</dcx-dai:insertions>
+                <dcx-dai:surname>Aarden</dcx-dai:surname>
+                <dcx-dai:DAI>123456789</dcx-dai:DAI>
+                <dcx-dai:role>Distributor</dcx-dai:role>
+                <dcx-dai:organization>
+                    <dcx-dai:name xml:lang="en">Utrecht University</dcx-dai:name>
+                </dcx-dai:organization>
+            </dcx-dai:author>
+        </dcx-dai:creatorDetails>
+        <ddm:created>2012-12</ddm:created>
+        <ddm:available>2013-05</ddm:available>
+        <ddm:audience>D20000</ddm:audience>
+        <ddm:audience>D24000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS_FOR_REGISTERED_USERS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dct:license xsi:type="dct:URI">http://creativecommons.org/publicdomain/zero/1.0</dct:license>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/metadata/files.xml
+++ b/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/metadata/files.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<files xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:dcterms="http://purl.org/dc/terms/">
+    <file filepath="data/leeg.txt">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+</files>
+

--- a/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/tagmanifest-md5.txt
+++ b/src/test/resources/bags/ddm-CC-0-license-but-no-rightsholder/tagmanifest-md5.txt
@@ -1,0 +1,5 @@
+92ac5935be5faca8d7ab78f010bda5a5  bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
+49c4fb4dad642f9adddfe9031114f530  manifest-md5.txt
+f165618dab90cbe8805c12e376294592  metadata/dataset.xml
+a003fcd89e806445ce040287222943bf  metadata/files.xml

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -105,6 +105,12 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
       includedInErrorMsg = "rightsHolder")
   }
 
+  it should "succeed if there is no rights holder but license is CC-0" in {
+    testRuleSuccess(
+      rule = ddmMayContainDctermsLicenseFromList(licenses),
+      inputBag = "ddm-CC-0-license-but-no-rightsholder")
+  }
+
   it should "fail if the license is not on the list" in {
     testRuleViolation(
       rule = ddmMayContainDctermsLicenseFromList(licenses),


### PR DESCRIPTION
Fixes EASY-2729

#### When applied it will
* Make Rightsholder optional for CC0 licensed deposits
* [ ] also update in bagit-profile?

#### Where should the reviewer @DANS-KNAW/easy start?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
