### PR TITLE
EASY-2731: memory leak voor easy-validate-dans-bag?

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/EasyValidateDansBagServlet.scala
@@ -38,7 +38,7 @@ class EasyValidateDansBagServlet(app: EasyValidateDansBagApp) extends ScalatraSe
   }
 
   post("/validate") {
-    val result = for {
+    (for {
       accept <- Try { request.getHeader("Accept") }
       infoPackageType <- params.get("infoPackageType").map(InfoPackageType.fromString).getOrElse { Success(InfoPackageType.SIP) }
       bagStoreUrl <- params.get("bag-store").map(getBagStoreUrl).sequence[Try, URI]
@@ -48,9 +48,8 @@ class EasyValidateDansBagServlet(app: EasyValidateDansBagApp) extends ScalatraSe
         if (accept == "application/json") message.toJson
         else message.toPlainText
       }
-    } yield Ok(body)
-
-    result.getOrRecover {
+    } yield Ok(body))
+    .getOrRecover {
       case t: IllegalArgumentException =>
         logger.warn(s"validation of bag failed with message: ${ t.getMessage } ")
         BadRequest(s"Input error: ${ t.getMessage }")

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/TargetBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/TargetBag.scala
@@ -34,21 +34,12 @@ import scala.xml.{ Node, Utility, XML }
  * @param profileVersion the profile version used
  */
 class TargetBag(val bagDir: BagDir, profileVersion: ProfileVersion = 0) {
-  private val bagReader = new BagReader()
-  private val ddmPath = profileVersion match {
-    case 0 => Paths.get("metadata/dataset.xml")
-    case 1 => Paths.get("data/pdi/dataset.xml")
-  }
-  private val filesXmlPath = profileVersion match {
-    case 0 => Paths.get("metadata/files.xml")
-    case 1 => Paths.get("data/pdi/files.xml")
-  }
 
   lazy val tryBag: Try[Bag] = Try { bagReader.read(bagDir.path) }
 
   lazy val tryDdm: Try[Node] = Try {
     Utility.trim {
-      XML.loadFile((bagDir / ddmPath.toString).toJava)
+      XML.loadFile((bagDir / ddmPaths(profileVersion).toString).toJava)
     }
   }.recoverWith {
     case t: Throwable => Try { fail(s"Unparseable XML: ${ t.getMessage }") }
@@ -56,7 +47,7 @@ class TargetBag(val bagDir: BagDir, profileVersion: ProfileVersion = 0) {
 
   lazy val tryFilesXml: Try[Node] = Try {
     Utility.trim {
-      XML.loadFile((bagDir / filesXmlPath.toString).toJava)
+      XML.loadFile((bagDir / filesXmlPaths(profileVersion).toString).toJava)
     }
   }.recoverWith {
     case t: Throwable => Try { fail(s"Unparseable XML: ${ t.getMessage }") }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/XmlValidator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/XmlValidator.scala
@@ -28,12 +28,12 @@ import scala.util.Try
 class XmlValidator(schema: Schema) {
 
   val validator = schema.newValidator()
-  val errorHandler = new AccumulatingErrorHandler
-  validator.setErrorHandler(errorHandler)
 
   def validate(is: InputStream): Try[Unit] = {
+    val errorHandler = new AccumulatingErrorHandler
     Try {
-        validator.validate(new StreamSource(is))
+      validator.setErrorHandler(errorHandler)
+      validator.validate(new StreamSource(is))
     }.flatMap(_ => errorHandler.errors.toList.map(x => Try[Unit] { throw x }).collectResults.map(_ => ()))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/XmlValidator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/XmlValidator.scala
@@ -27,11 +27,12 @@ import scala.util.Try
 
 class XmlValidator(schema: Schema) {
 
+  val validator = schema.newValidator()
+  val errorHandler = new AccumulatingErrorHandler
+  validator.setErrorHandler(errorHandler)
+
   def validate(is: InputStream): Try[Unit] = {
-    val errorHandler = new AccumulatingErrorHandler
     Try {
-        val validator = schema.newValidator()
-        validator.setErrorHandler(errorHandler)
         validator.validate(new StreamSource(is))
     }.flatMap(_ => errorHandler.errors.toList.map(x => Try[Unit] { throw x }).collectResults.map(_ => ()))
   }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/package.scala
@@ -15,7 +15,10 @@
  */
 package nl.knaw.dans.easy
 
+import java.nio.file.Paths
+
 import better.files._
+import gov.loc.repository.bagit.reader.BagReader
 import nl.knaw.dans.easy.validatebag.rules.{ ProfileVersion0, ProfileVersion1 }
 
 import scala.util.{ Failure, Try }
@@ -32,6 +35,10 @@ package object validatebag {
     0 -> ProfileVersion0.versionUri,
     1 -> ProfileVersion1.versionUri,
   )
+
+  val bagReader = new BagReader()
+  val ddmPaths = Map(0 -> Paths.get("metadata/dataset.xml"), 1 -> Paths.get("data/pdi/files.xml"))
+  val filesXmlPaths = Map(0 -> Paths.get("metadata/files.xml"), 1 -> Paths.get("data/pdi/files.xml"))
 
   object InfoPackageType extends Enumeration {
     type InfoPackageType = Value

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/bagit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/bagit/package.scala
@@ -144,7 +144,7 @@ package object bagit extends DebugEnhancedLogging {
 
   def bagInfoCreatedElementIsIso8601Date(t: TargetBag): Try[Unit] = {
     trace(())
-    val result = for {
+    (for {
       bag <- t.tryBag
       valueOfCreated <- Option(bag.getMetadata.get("Created"))
         .map {
@@ -153,9 +153,8 @@ package object bagit extends DebugEnhancedLogging {
         }
         .getOrElse(Failure(RuleViolationDetailsException("No Created-entry found in bag-info.txt")))
       _ = DateTime.parse(valueOfCreated, ISODateTimeFormat.dateTime)
-    } yield ()
-
-    result.map(_ => ()).recoverWith {
+    } yield ())
+      .map(_ => ()).recoverWith {
       case e: RuleViolationDetailsException => Failure(e)
       case _: Throwable =>
         Failure(RuleViolationDetailsException("Created-entry in bag-info.txt not in correct ISO 8601 format"))

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -153,7 +153,7 @@ class MetadataRulesSpec extends TestSupportFixture with CanConnectFixture {
   }
 
   private val allRules: Seq[NumberedRule] = {
-    val xmlValidator = new XmlValidator(null) {
+    val xmlValidator = new XmlValidator(schemaFactory.newSchema) {
       override def validate(is: InputStream): Try[Unit] = Success(())
     }
     val validatorMap = Map("dataset.xml" -> xmlValidator, "files.xml" -> xmlValidator, "agreements.xml" -> xmlValidator)

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/profile/NumberedRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/profile/NumberedRulesSpec.scala
@@ -15,16 +15,19 @@
  */
 package nl.knaw.dans.easy.validatebag.rules.profile
 
+import javax.xml.validation.{ Schema, SchemaFactory }
 import nl.knaw.dans.easy.validatebag._
 import nl.knaw.dans.easy.validatebag.rules.{ ProfileVersion0, ProfileVersion1 }
 import org.scalatest.Inspectors
 
 class NumberedRulesSpec extends TestSupportFixture with Inspectors {
 
+  private val schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema")
+
   private val xmlValidators: Map[String, XmlValidator] = Map(
-    "dataset.xml" -> new XmlValidator(null),
-    "files.xml" -> new XmlValidator(null),
-    "agreements.xml" -> new XmlValidator(null)
+    "dataset.xml" -> new XmlValidator(schemaFactory.newSchema),
+    "files.xml" -> new XmlValidator(schemaFactory.newSchema),
+    "agreements.xml" -> new XmlValidator(schemaFactory.newSchema)
   )
 
   private val allRules: Map[ProfileVersion, RuleBase] = {


### PR DESCRIPTION
Fixes EASY-2731

#### When applied it will
* take care that less `variables` will be created (that are not cleaned up by `gc`) and thus less `heap` memory

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-auth-info                      | [PR#40](https://github.com/DANS-KNAW/easy-auth-info/pull/40)     | ..
