### PR TITLE
EASY-2759: license.html added to files that are allowed in metadata directory

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -66,6 +66,7 @@ object ProfileVersion0 {
         "amd.xml",
         "emd.xml",
         "license.txt",
+        "license.html",
         "depositor-info",
         "depositor-info/agreements.xml",
         "depositor-info/message-from-depositor.txt",

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
@@ -81,6 +81,7 @@ class StructuralRulesSpec extends TestSupportFixture {
         "amd.xml",
         "emd.xml",
         "license.txt",
+        "license.html",
         "depositor-info",
         "depositor-info/agreements.xml",
         "depositor-info/message-from-depositor.txt",


### PR DESCRIPTION
Fixes EASY-2759

#### When applied it will
* add `license.html` to files that are allowed in `metadata` directory


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
