### PR TITLE
EASY-2775 Make rule 4.2 an AIP-only check in easy-validate-dans-bag

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -108,7 +108,7 @@ object ProfileVersion0 {
 
 
     // BAG-SEQUENCE
-    NumberedRule("4.2", bagInfoIsVersionOfIfExistsPointsToArchivedBag(bagStore), dependsOn = List("1.2.5")),
+    NumberedRule("4.2", bagInfoIsVersionOfIfExistsPointsToArchivedBag(bagStore), AIP, dependsOn = List("1.2.5")),
     NumberedRule("4.3", storeSameAsInArchivedBag(bagStore), AIP, dependsOn = List("1.2.5")),
     NumberedRule("4.4", userSameAsInArchivedBag(bagStore), AIP, dependsOn = List("1.2.5"))
   )


### PR DESCRIPTION
Fixes EASY-2775

#### When applied it will
* Make rule 4.2 an AIP-only check in easy-validate-dans-bag
