### PR TITLE
Upgraded parent to be compatible with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ matrix:
       cache:
         directories:
           - "$HOME/.m2/repository"
+    - language: java
+      jdk: openjdk11
+      cache:
+        directories:
+          - "$HOME/.m2/repository"
     - language: python
       if: branch = master AND NOT type = pull_request
       python: 3.7.1

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>


### PR DESCRIPTION
DD-326

#### When applied it will
* Upgrade parent
* Refactor a bit of code that was not compatible with Java 11.

#### How should this be manually tested?

* Check that is compiles under both Java 11 and 8:
  ```
  brew install brew install adoptopenjdk11
  export JAVA_HOME=`/usr/libexec/java_home -v 11`
  java -version
  mvn clean install
  export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
  java -version
  mvn clean install
  ```
* Check that the refactored code still works. For this you would need to do an AIP-type check with an update-deposit to see that contains the same EASY-User-Account value as the bags in the sequence in bag-store that it updates.


#### Related pull requests on github
* https://github.com/DANS-KNAW/dd-dtap/pull/70
