### PR TITLE
DD-556: No special chars in folder names

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
@@ -56,8 +56,8 @@ package object structural extends DebugEnhancedLogging {
     trace(filesInManifest.mkString(", "))
 
     val invalidCharacters = """:*?"<>|;#"""
-    val invalidFiles = filesInManifest.filter { path =>
-      invalidCharacters.exists(c => path.name.contains(c))
+    val invalidFiles = filesInManifest.filter { file =>
+      invalidCharacters.exists(c => file.pathAsString.contains(c))
     }
     trace(invalidFiles.mkString(", "))
     trace(invalidFiles.nonEmpty)

--- a/src/test/resources/bags/bagit-payload-files-with-invalid-chars/manifest-md5.txt
+++ b/src/test/resources/bags/bagit-payload-files-with-invalid-chars/manifest-md5.txt
@@ -1,2 +1,2 @@
 d41d8cd98f00b204e9800998ecf8427e  data/l:eeg.txt
-d41d8cd98f00b204e9800998ecf8427e  data/sub/sub/vacio.txt
+d41d8cd98f00b204e9800998ecf8427e  data/sub>!/sub/vacio.txt

--- a/src/test/resources/bags/bagit-payload-files-with-invalid-chars/tagmanifest-md5.txt
+++ b/src/test/resources/bags/bagit-payload-files-with-invalid-chars/tagmanifest-md5.txt
@@ -1,2 +1,2 @@
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
-ccf0caf94049ea4226dcc1e71bc001e8  manifest-md5.txt
+e50a795937bcac781c6c239c9f6c67df  manifest-md5.txt

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
@@ -126,19 +126,11 @@ class StructuralRulesSpec extends TestSupportFixture {
     )
   }
 
-  it should "fail if a payload file name has invalid characters" in {
+  it should "fail if a payload file path has invalid characters" in {
     testRuleViolationRegex(
       hasOnlyValidFileNames,
       inputBag = "bagit-payload-files-with-invalid-chars",
-      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/l:eeg.txt".r
-    )
-  }
-
-  it should "fail if a payload filepath has invalid characters" in {
-    testRuleViolationRegex(
-      hasOnlyValidFileNames,
-      inputBag = "bagit-payload-files-with-invalid-chars",
-      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/sub>!/sub/vacio.txt".r
+      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/sub>!/sub/vacio.txt, .*/data/l:eeg.txt".r
     )
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
@@ -126,11 +126,19 @@ class StructuralRulesSpec extends TestSupportFixture {
     )
   }
 
-  it should "fail if a payload file has invalid characters" in {
+  it should "fail if a payload file name has invalid characters" in {
     testRuleViolationRegex(
       hasOnlyValidFileNames,
       inputBag = "bagit-payload-files-with-invalid-chars",
       includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/l:eeg.txt".r
+    )
+  }
+
+  it should "fail if a payload filepath has invalid characters" in {
+    testRuleViolationRegex(
+      hasOnlyValidFileNames,
+      inputBag = "bagit-payload-files-with-invalid-chars",
+      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/sub>!/sub/vacio.txt".r
     )
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/structural/StructuralRulesSpec.scala
@@ -126,11 +126,19 @@ class StructuralRulesSpec extends TestSupportFixture {
     )
   }
 
+  it should "fail if a payload file name has invalid characters" in {
+    testRuleViolationRegex(
+      hasOnlyValidFileNames,
+      inputBag = "bagit-payload-files-with-invalid-chars",
+      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/l:eeg.txt".r
+    )
+  }
+
   it should "fail if a payload file path has invalid characters" in {
     testRuleViolationRegex(
       hasOnlyValidFileNames,
       inputBag = "bagit-payload-files-with-invalid-chars",
-      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/sub>!/sub/vacio.txt, .*/data/l:eeg.txt".r
+      includedInErrorMsg = "Payload files must have valid characters. Invalid ones: .*/data/sub>!/sub/vacio.txt".r
     )
   }
 }


### PR DESCRIPTION
Fixes DD-556

#### When applied it will
* check that there are no `non-allowed characters` in the whole `filepath`, not only in the filename

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
dans-bagit-profile                      | [PR#20](https://github.com/DANS-KNAW/dans-bagit-profile/pull/20)     | ..
