### PR TITLE
EASY-2846: PR on PR, compares files.xml paths with original-filepaths.txt

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/ProfileVersion0.scala
@@ -103,6 +103,7 @@ object ProfileVersion0 {
     NumberedRule("3.2.2", filesXmlHasDocumentElementFiles, dependsOn = List("2.2(b)")),
     NumberedRule("3.2.3", filesXmlHasOnlyFiles, dependsOn = List("3.2.2")),
     NumberedRule("3.2.4", filesXmlFileElementsAllHaveFilepathAttribute, dependsOn = List("3.2.3")),
+    NumberedRule("3.2.4b", filesXmlFileElementsInOriginalFilePaths, dependsOn = List("3.2.3","2.7.1", "2.2(b)", "3.2.4")),
     // Second part of 3.2.4 (directories not described) is implicitly checked by 3.2.5
     NumberedRule("3.2.5", filesXmlNoDuplicatesAndMatchesWithPayloadPlusPreStagedFiles, dependsOn = List("1.1.1(datadir)", "3.2.4")),
     NumberedRule("3.2.6", filesXmlAllFilesHaveFormat, dependsOn = List("3.2.2")),

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -521,7 +521,7 @@ package object metadata extends DebugEnhancedLogging {
             .map(_.get)
             .toSet
             .diff(physicalToOriginalBagRelativePaths.values.toSet)
-          if (notInOriginalPaths.isEmpty)
+          if (notInOriginalPaths.nonEmpty)
             fail(s"${ notInOriginalPaths.size } 'filepath' attributes are not found in 'original-filepaths.txt' ${ notInOriginalPaths.mkString(", ") }. ")
         }
     }

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
@@ -71,7 +71,7 @@ package object structural extends DebugEnhancedLogging {
     (t.bagDir / originalFilepathsFile).exists
   }
 
-  def readOriginalFilepaths(t: TargetBag): Map[String, String] = {
+  def readPhysicalToOriginalBagRelativePaths(t: TargetBag): Map[String, String] = {
     val fileToCheck = t.bagDir / originalFilepathsFile
     fileToCheck.lines.map { line =>
       val list = line.split("""[ \t]+""", 2)
@@ -87,7 +87,7 @@ package object structural extends DebugEnhancedLogging {
       val pathsInFilesXmlList = files.map(_ \@ "filepath")
       val pathsInFileXml = pathsInFilesXmlList.toSet
       val filesInBagPayload = (t.bagDir / "data").walk().filter(_.isRegularFile).toSet
-      val physicalToOriginalBagRelativePaths = readOriginalFilepaths(t)
+      val physicalToOriginalBagRelativePaths = readPhysicalToOriginalBagRelativePaths(t)
       val payloadPaths = filesInBagPayload.map(t.bagDir.path relativize _).map(_.toString)
       val originalFileSetsEqual = pathsInFileXml == physicalToOriginalBagRelativePaths.values.toSet
       val physicalFileSetsEqual = payloadPaths == physicalToOriginalBagRelativePaths.keySet

--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/structural/package.scala
@@ -19,11 +19,10 @@ import better.files.File.apply
 import nl.knaw.dans.easy.validatebag.TargetBag
 import nl.knaw.dans.easy.validatebag.validation.fail
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import java.nio.file.{ Path, Paths }
 
+import java.nio.file.Path
 import scala.collection.JavaConverters._
 import scala.collection.Set
-import scala.collection.mutable.ListBuffer
 import scala.util.Try
 
 package object structural extends DebugEnhancedLogging {
@@ -51,8 +50,8 @@ package object structural extends DebugEnhancedLogging {
   def hasOnlyValidFileNames(t: TargetBag): Try[Unit] = Try {
     trace(())
     val filesInManifest = t.tryBag.map { bag =>
-      bag.getPayLoadManifests.asScala.headOption.getOrElse(fail(s"Dependent rule should have failed: no manifest found for ${t.bagDir}"))
-    }.getOrElse(fail(s"Dependent rule should have failed: Could not get bag ${t.bagDir}"))
+      bag.getPayLoadManifests.asScala.headOption.getOrElse(fail(s"Dependent rule should have failed: no manifest found for ${ t.bagDir }"))
+    }.getOrElse(fail(s"Dependent rule should have failed: Could not get bag ${ t.bagDir }"))
       .getFileToChecksumMap.keySet().asScala.toArray[Path]
     trace(filesInManifest.mkString(", "))
 
@@ -67,36 +66,31 @@ package object structural extends DebugEnhancedLogging {
   }
 
   val originalFilepathsFile = "original-filepaths.txt"
+
   def rootContainsOriginalFilepathsFile(t: TargetBag): Boolean = {
     (t.bagDir / originalFilepathsFile).exists
   }
 
-  def readOriginalFilepaths(t: TargetBag): (Set[String], Set[String]) = {
+  def readOriginalFilepaths(t: TargetBag): Map[String, String] = {
     val fileToCheck = t.bagDir / originalFilepathsFile
-    var physicalBagRelativePaths = Set[String]()
-    var originalBagRelativePaths = Set[String]()
-    fileToCheck.lines.foreach {
-      line: String =>
-        if(line.indexOf(' ') <= 0) fail(s"Format of ${ originalFilepathsFile } is not valid")
-        val physicalBagRelativePath = line.substring(0, line.indexOf(' '))
-        val originalBagRelativePath = line.substring(line.indexOf(' ')+1)
-        physicalBagRelativePaths += physicalBagRelativePath
-        originalBagRelativePaths += originalBagRelativePath
-    }
-    ( physicalBagRelativePaths, originalBagRelativePaths )
+    fileToCheck.lines.map { line =>
+      val list = line.split("""[ \t]+""", 2)
+      if (list.size != 2) throw new Exception(s"invalid line in $originalFilepathsFile : $line")
+      (list(0), list(1))
+    }.toMap
   }
 
-  def isOriginalFilepathsFileComplete(t: TargetBag): Try[Unit] =  {
+  def isOriginalFilepathsFileComplete(t: TargetBag): Try[Unit] = {
     trace(())
     t.tryFilesXml.map { xml =>
       val files = xml \ "file"
       val pathsInFilesXmlList = files.map(_ \@ "filepath")
       val pathsInFileXml = pathsInFilesXmlList.toSet
       val filesInBagPayload = (t.bagDir / "data").walk().filter(_.isRegularFile).toSet
-      val (physicalBagRelativePaths, originalBagRelativePaths) = readOriginalFilepaths(t)
+      val physicalToOriginalBagRelativePaths = readOriginalFilepaths(t)
       val payloadPaths = filesInBagPayload.map(t.bagDir.path relativize _).map(_.toString)
-      val originalFileSetsEqual = pathsInFileXml == originalBagRelativePaths
-      val physicalFileSetsEqual = payloadPaths == physicalBagRelativePaths
+      val originalFileSetsEqual = pathsInFileXml == physicalToOriginalBagRelativePaths.values.toSet
+      val physicalFileSetsEqual = payloadPaths == physicalToOriginalBagRelativePaths.keySet
 
       if (originalFileSetsEqual && physicalFileSetsEqual) ()
       else {
@@ -106,16 +100,16 @@ package object structural extends DebugEnhancedLogging {
           else s"only in $name: " + set.mkString("{", ", ", "}")
         }
 
-        lazy val onlyInBag = stringDiff("payload", payloadPaths, physicalBagRelativePaths.toSet)
-        lazy val onlyInFilesXml = stringDiff("files.xml", pathsInFileXml, originalBagRelativePaths.toSet)
-        lazy val onlyInFilepathsPhysical = stringDiff("physical-bag-relative-path", physicalBagRelativePaths.toSet, payloadPaths)
-        lazy val onlyInFilepathsOriginal = stringDiff("original-bag-relative-path", originalBagRelativePaths.toSet, pathsInFileXml)
+        lazy val onlyInBag = stringDiff("payload", payloadPaths, physicalToOriginalBagRelativePaths.keySet)
+        lazy val onlyInFilesXml = stringDiff("files.xml", pathsInFileXml, physicalToOriginalBagRelativePaths.values.toSet)
+        lazy val onlyInFilepathsPhysical = stringDiff("physical-bag-relative-path", physicalToOriginalBagRelativePaths.keySet, payloadPaths)
+        lazy val onlyInFilepathsOriginal = stringDiff("original-bag-relative-path", physicalToOriginalBagRelativePaths.values.toSet, pathsInFileXml)
 
         val msg1 = if (physicalFileSetsEqual) ""
-                   else s"   - Physical file paths in ${ originalFilepathsFile } not equal to payload in data dir. Difference - " +
+                   else s"   - Physical file paths in $originalFilepathsFile not equal to payload in data dir. Difference - " +
                      s"$onlyInBag $onlyInFilepathsPhysical"
         val msg2 = if (originalFileSetsEqual) ""
-                   else s"   - Original file paths in ${ originalFilepathsFile } not equal to filepaths in files.xml. Difference - " +
+                   else s"   - Original file paths in $originalFilepathsFile not equal to filepaths in files.xml. Difference - " +
                      s"$onlyInFilepathsOriginal $onlyInFilesXml"
 
         val msg = msg1 + msg2

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -368,7 +368,7 @@ class MetadataRulesSpec extends TestSupportFixture with SchemaFixture with CanCo
     testRuleViolation(
       rule = filesXmlFileElementsAllHaveFilepathAttribute,
       inputBag = "filesxml-file-element-without-filepath",
-      includedInErrorMsg = "Not all 'file' elements have a 'filepath' attribute")
+      includedInErrorMsg = "1 'file' element(s) don't have a 'filepath' attribute")
   }
 
   "filesXmlNoDuplicatesAndMatchesWithPayloadPlusPreStagedFiles" should "fail if a file is described twice" in {

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -371,6 +371,21 @@ class MetadataRulesSpec extends TestSupportFixture with SchemaFixture with CanCo
       includedInErrorMsg = "1 'file' element(s) don't have a 'filepath' attribute")
   }
 
+  "filesXmlFileElementsInOriginalFilePaths" should "succeed on a valid bag with 'original-filepaths.txt'" in {
+    testRuleSuccess(
+      rule = filesXmlFileElementsInOriginalFilePaths,
+      inputBag = "original-filepaths-valid-bag",
+    )
+  }
+
+  "filesXmlFileElementsInOriginalFilePaths" should "fail if a file element has no filepath attribute" in {
+    testRuleViolation(
+      rule = filesXmlFileElementsInOriginalFilePaths,
+      inputBag = "original-filepaths-non-valid-bag",
+      includedInErrorMsg = "2 'filepath' attributes are not found in 'original-filepaths.txt' data/sub/sub/sine-md5.txt, data/sub/sub/vacio-or-so.txt. ",
+    )
+  }
+
   "filesXmlNoDuplicatesAndMatchesWithPayloadPlusPreStagedFiles" should "fail if a file is described twice" in {
     testRuleViolation(
       rule = filesXmlNoDuplicatesAndMatchesWithPayloadPlusPreStagedFiles,


### PR DESCRIPTION
Completes #108 

#### When applied it will
* [x] unit tests
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* build deploy on deasy
* copy `easy-validate-dans-bag/src/test/resources/bags/original-filepaths-non-valid-bag` to `dtap/easy-dtap/shared`
* on deasy `easy-validate-dans-bag /vagrant/shared/original-filepaths-non-valid-bag/`
* it fails with more messages than 

       - [3.2.4b] 2 'filepath' attributes are not found in 'original-filepaths.txt' data/sub/sub/sine-md5.txt, data/sub/sub/vacio-or-so.txt.

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
