### PR TITLE
Made ordering in reporting of differences deterministic

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala
@@ -546,10 +546,10 @@ package object metadata extends DebugEnhancedLogging {
 
         if (noDuplicatesFound && fileSetsEqual) ()
         else {
-          def stringDiff[T](name: String, left: Set[T], right: Set[T]): String = {
+          def stringDiff(name: String, left: Set[String], right: Set[String]): String = {
             val set = left diff right
             if (set.isEmpty) ""
-            else s"only in $name: " + set.mkString("{", ", ", "}")
+            else s"only in $name: " + set.toList.sorted.mkString("{", ", ", "}")
           }
 
           lazy val onlyInBag = stringDiff("bag", payloadPaths, pathsInFileXml)
@@ -557,7 +557,7 @@ package object metadata extends DebugEnhancedLogging {
           lazy val onlyInFilesXml = stringDiff("files.xml", pathsInFileXml, payloadAndPreStagedFilePaths)
 
           val msg1 = if (noDuplicatesFound) ""
-          else s"   - Duplicate filepaths found: ${duplicatePathsInFilesXml.mkString("{", ", ", "}")}\n"
+          else s"   - Duplicate filepaths found: ${duplicatePathsInFilesXml.toList.sorted.mkString("{", ", ", "}")}\n"
           val msg2 = if (fileSetsEqual) ""
           else "   - Filepaths in files.xml not equal to files found in data folder. Difference - " +
             s"$onlyInBag $onlyInPreStaged $onlyInFilesXml"

--- a/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.validatebag/rules/metadata/MetadataRulesSpec.scala
@@ -429,7 +429,7 @@ class MetadataRulesSpec extends TestSupportFixture with SchemaFixture with CanCo
     testRuleViolation(
       rule = filesXmlNoDuplicatesAndMatchesWithPayloadPlusPreStagedFiles,
       inputBag = "metadata-pre-staged-csv-all-three-differ",
-      includedInErrorMsg = "Filepaths in files.xml not equal to files found in data folder. Difference - only in bag: {data/leeg5.txt, data/leeg4.txt} only in pre-staged.csv: {data/leeg6.txt} only in files.xml: {data/leeg3.txt}"
+      includedInErrorMsg = "Filepaths in files.xml not equal to files found in data folder. Difference - only in bag: {data/leeg4.txt, data/leeg5.txt} only in pre-staged.csv: {data/leeg6.txt} only in files.xml: {data/leeg3.txt}"
     )
   }
 


### PR DESCRIPTION
NO JIRA

# Description of changes
The list of files in the reporting of differences between `files.xml` and contents of `data/` folder are now always sorted, so the unit test no longer relies on system specific default ordering.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
@DANS-KNAW/easy
